### PR TITLE
Fix SDC broken image links

### DIFF
--- a/retrorom-titles.json
+++ b/retrorom-titles.json
@@ -59880,6370 +59880,6370 @@
   "0550000000010000": {
     "id": "0550000000010000",
     "name": "102 Dalmatians - Puppies to the Rescue [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/102%20Dalmatians%20-%20Puppies%20to%20the%20Rescue%20(UK).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/102%20Dalmatians%20-%20Puppies%20to%20the%20Rescue.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000000000 and rom copier for roms/sdc/102 Dalmatians - Puppies to the Rescue.chd"
   },
   "0550000000030000": {
     "id": "0550000000030000",
     "name": "18 Wheeler - American Pro Trucker (1) [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/18%20Wheeler%20-%20American%20Pro%20Trucker%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/18%20Wheeler%20-%20American%20Pro%20Trucker.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000020000 and rom copier for roms/sdc/18 Wheeler - American Pro Trucker (1).chd"
   },
   "0550000000050000": {
     "id": "0550000000050000",
     "name": "18 Wheeler - American Pro Trucker (2) [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/18%20Wheeler%20-%20American%20Pro%20Trucker%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/18%20Wheeler%20-%20American%20Pro%20Trucker.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000040000 and rom copier for roms/sdc/18 Wheeler - American Pro Trucker (2).chd"
   },
   "0550000000070000": {
     "id": "0550000000070000",
     "name": "18 Wheeler - American Pro Trucker [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/18%20Wheeler%20-%20American%20Pro%20Trucker%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/18%20Wheeler%20-%20American%20Pro%20Trucker.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000060000 and rom copier for roms/sdc/18 Wheeler - American Pro Trucker.chd"
   },
   "0550000000090000": {
     "id": "0550000000090000",
     "name": "21 - Two One [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/21%20-%20Two%20One%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/21%20-%20Two%20One.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000080000 and rom copier for roms/sdc/21 - Two One.chd"
   },
   "05500000000B0000": {
     "id": "05500000000B0000",
     "name": "4 Wheel Thunder [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/4%20Wheel%20Thunder%20(Europe)%20(En,Fr).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/4%20Wheel%20Thunder.png",
     "region": "US",
     "description": "Forwarder installer for 05500000000a0000 and rom copier for roms/sdc/4 Wheel Thunder.chd"
   },
   "05500000000D0000": {
     "id": "05500000000D0000",
     "name": "4x4 Evo [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/4x4%20Evo%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/4x4%20Evo.png",
     "region": "US",
     "description": "Forwarder installer for 05500000000c0000 and rom copier for roms/sdc/4x4 Evo.chd"
   },
   "05500000000F0000": {
     "id": "05500000000F0000",
     "name": "90 Minutes - Sega Championship Football [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/90%20Minutes%20-%20Sega%20Championship%20Football%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/90%20Minutes%20-%20Sega%20Championship%20Football.png",
     "region": "US",
     "description": "Forwarder installer for 05500000000e0000 and rom copier for roms/sdc/90 Minutes - Sega Championship Football.chd"
   },
   "0550000000110000": {
     "id": "0550000000110000",
     "name": "Advanced Daisenryaku - Sturm ueber Europa - Der Deutsche Blitzkrieg [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Advanced%20Daisenryaku%20-%20Sturm%20ueber%20Europa%20-%20Der%20Deutsche%20Blitzkrieg%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Advanced%20Daisenryaku%20-%20Sturm%20ueber%20Europa%20-%20Der%20Deutsche%20Blitzkrieg.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000100000 and rom copier for roms/sdc/Advanced Daisenryaku - Sturm ueber Europa - Der Deutsche Blitzkrieg.chd"
   },
   "0550000000130000": {
     "id": "0550000000130000",
     "name": "Advanced Daisenryaku 2001 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Advanced%20Daisenryaku%202001%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Advanced%20Daisenryaku%202001.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000120000 and rom copier for roms/sdc/Advanced Daisenryaku 2001.chd"
   },
   "0550000000150000": {
     "id": "0550000000150000",
     "name": "Aero Dancing - Todoroki Taichou no Himitsu Disc [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Aero%20Dancing%20-%20Todoroki%20Taichou%20no%20Himitsu%20Disc%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Aero%20Dancing%20-%20Todoroki%20Taichou%20no%20Himitsu%20Disc.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000140000 and rom copier for roms/sdc/Aero Dancing - Todoroki Taichou no Himitsu Disc.chd"
   },
   "0550000000170000": {
     "id": "0550000000170000",
     "name": "Aero Dancing F - Todoroki Tsubasa no Hatsu Hikou [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Aero%20Dancing%20F%20-%20Todoroki%20Tsubasa%20no%20Hatsu%20Hikou%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Aero%20Dancing%20F%20-%20Todoroki%20Tsubasa%20no%20Hatsu%20Hikou.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000160000 and rom copier for roms/sdc/Aero Dancing F - Todoroki Tsubasa no Hatsu Hikou.chd"
   },
   "0550000000190000": {
     "id": "0550000000190000",
     "name": "Aero Dancing F [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Aero%20Dancing%20F%20(Japan)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Aero%20Dancing%20F.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000180000 and rom copier for roms/sdc/Aero Dancing F.chd"
   },
   "05500000001B0000": {
     "id": "05500000001B0000",
     "name": "Aero Dancing featuring Blue Impulse [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Aero%20Dancing%20featuring%20Blue%20Impulse%20(Japan)%20(Tentou%20Taikenban).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Aero%20Dancing%20featuring%20Blue%20Impulse.png",
     "region": "US",
     "description": "Forwarder installer for 05500000001a0000 and rom copier for roms/sdc/Aero Dancing featuring Blue Impulse.chd"
   },
   "05500000001D0000": {
     "id": "05500000001D0000",
     "name": "Aero Dancing i - Jikai-saku made Matemasen [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Aero%20Dancing%20i%20-%20Jikai-saku%20made%20Matemasen%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Aero%20Dancing%20i%20-%20Jikai-saku%20made%20Matemasen.png",
     "region": "US",
     "description": "Forwarder installer for 05500000001c0000 and rom copier for roms/sdc/Aero Dancing i - Jikai-saku made Matemasen.chd"
   },
   "05500000001F0000": {
     "id": "05500000001F0000",
     "name": "Aero Dancing i [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Aero%20Dancing%20i%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Aero%20Dancing%20i.png",
     "region": "US",
     "description": "Forwarder installer for 05500000001e0000 and rom copier for roms/sdc/Aero Dancing i.chd"
   },
   "0550000000210000": {
     "id": "0550000000210000",
     "name": "AeroWings (1) [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/AeroWings%20(Europe)%20(En,Fr,De).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/AeroWings.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000200000 and rom copier for roms/sdc/AeroWings (1).chd"
   },
   "0550000000230000": {
     "id": "0550000000230000",
     "name": "AeroWings 2 - Airstrike [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/AeroWings%202%20-%20Airstrike%20(Europe)%20(En,De).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/AeroWings%202%20-%20Airstrike.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000220000 and rom copier for roms/sdc/AeroWings 2 - Airstrike.chd"
   },
   "0550000000250000": {
     "id": "0550000000250000",
     "name": "AeroWings [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/AeroWings%20(Europe)%20(En,Fr,De).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/AeroWings.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000240000 and rom copier for roms/sdc/AeroWings.chd"
   },
   "0550000000270000": {
     "id": "0550000000270000",
     "name": "After... Wasureenu Kizuna [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/After...%20Wasureenu%20Kizuna%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/After...%20Wasureenu%20Kizuna.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000260000 and rom copier for roms/sdc/After... Wasureenu Kizuna.chd"
   },
   "0550000000290000": {
     "id": "0550000000290000",
     "name": "Aikagi - Hidamari to Kanojo no Heyagi [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Aikagi%20-%20Hidamari%20to%20Kanojo%20no%20Heyagi%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Aikagi%20-%20Hidamari%20to%20Kanojo%20no%20Heyagi.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000280000 and rom copier for roms/sdc/Aikagi - Hidamari to Kanojo no Heyagi.chd"
   },
   "05500000002B0000": {
     "id": "05500000002B0000",
     "name": "Air [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Air%20(Japan)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Air.png",
     "region": "US",
     "description": "Forwarder installer for 05500000002a0000 and rom copier for roms/sdc/Air.chd"
   },
   "05500000002D0000": {
     "id": "05500000002D0000",
     "name": "AirForce Delta [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/AirForce%20Delta%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/AirForce%20Delta.png",
     "region": "US",
     "description": "Forwarder installer for 05500000002c0000 and rom copier for roms/sdc/AirForce Delta.chd"
   },
   "05500000002F0000": {
     "id": "05500000002F0000",
     "name": "Akihabara Dennou-gumi Pata Pies! [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Akihabara%20Dennou-gumi%20Pata%20Pies!%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Akihabara%20Dennou-gumi%20Pata%20Pies!.png",
     "region": "US",
     "description": "Forwarder installer for 05500000002e0000 and rom copier for roms/sdc/Akihabara Dennou-gumi Pata Pies!.chd"
   },
   "0550000000310000": {
     "id": "0550000000310000",
     "name": "Alienfront Online [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Alienfront%20Online%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Alienfront%20Online.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000300000 and rom copier for roms/sdc/Alienfront Online.chd"
   },
   "0550000000330000": {
     "id": "0550000000330000",
     "name": "Alone in the Dark - The New Nightmare Disc #2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Alone%20in%20the%20Dark%20-%20The%20New%20Nightmare%20(Europe)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Alone%20in%20the%20Dark%20-%20The%20New%20Nightmare%20Disc%20%232.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000320000 and rom copier for roms/sdc/Alone in the Dark - The New Nightmare Disc #2.chd"
   },
   "0550000000350000": {
     "id": "0550000000350000",
     "name": "Alone in the Dark - The New Nightmare Disk #1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Alone%20in%20the%20Dark%20-%20The%20New%20Nightmare%20(Europe)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Alone%20in%20the%20Dark%20-%20The%20New%20Nightmare%20Disk%20%231.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000340000 and rom copier for roms/sdc/Alone in the Dark - The New Nightmare Disk #1.chd"
   },
   "0550000000370000": {
     "id": "0550000000370000",
     "name": "AM2 of CRI 2001 New Lineup Movie Collection [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Princess%20Maker%20Collection%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Princess%20Maker%20Collection.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000360000 and rom copier for roms/sdc/AM2 of CRI 2001 New Lineup Movie Collection.chd"
   },
   "0550000000390000": {
     "id": "0550000000390000",
     "name": "Angel Present [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Angel%20Present%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Angel%20Present.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000380000 and rom copier for roms/sdc/Angel Present.chd"
   },
   "05500000003B0000": {
     "id": "05500000003B0000",
     "name": "Angel Wish - Kimi no Egao ni Chu! [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Angel%20Wish%20-%20Kimi%20no%20Egao%20ni%20Chu!%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Angel%20Wish%20-%20Kimi%20no%20Egao%20ni%20Chu!.png",
     "region": "US",
     "description": "Forwarder installer for 05500000003a0000 and rom copier for roms/sdc/Angel Wish - Kimi no Egao ni Chu!.chd"
   },
   "05500000003D0000": {
     "id": "05500000003D0000",
     "name": "Animastar [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Animastar%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Animastar.png",
     "region": "US",
     "description": "Forwarder installer for 05500000003c0000 and rom copier for roms/sdc/Animastar.chd"
   },
   "05500000003F0000": {
     "id": "05500000003F0000",
     "name": "Ao no 6-gou - Saigetsu Hito o Matazu - Time and Tide [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ao%20no%206-gou%20-%20Saigetsu%20Hito%20o%20Matazu%20-%20Time%20and%20Tide%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ao%20no%206-gou%20-%20Saigetsu%20Hito%20o%20Matazu%20-%20Time%20and%20Tide.png",
     "region": "US",
     "description": "Forwarder installer for 05500000003e0000 and rom copier for roms/sdc/Ao no 6-gou - Saigetsu Hito o Matazu - Time and Tide.chd"
   },
   "0550000000410000": {
     "id": "0550000000410000",
     "name": "Aqua GT [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Aqua%20GT%20(Europe)%20(En,Fr,De).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Aqua%20GT.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000400000 and rom copier for roms/sdc/Aqua GT.chd"
   },
   "0550000000430000": {
     "id": "0550000000430000",
     "name": "Armada [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Armada%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Armada.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000420000 and rom copier for roms/sdc/Armada.chd"
   },
   "0550000000450000": {
     "id": "0550000000450000",
     "name": "Army Men - Sarge's Heroes [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Army%20Men%20-%20Sarge's%20Heroes%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Army%20Men%20-%20Sarge's%20Heroes.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000440000 and rom copier for roms/sdc/Army Men - Sarge's Heroes.chd"
   },
   "0550000000470000": {
     "id": "0550000000470000",
     "name": "Atari Anniversary Edition [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Atari%20Anniversary%20Edition%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Atari%20Anniversary%20Edition.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000460000 and rom copier for roms/sdc/Atari Anniversary Edition.chd"
   },
   "0550000000490000": {
     "id": "0550000000490000",
     "name": "Atsumare! Guru Guru Onsen BB [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Atsumare!%20Guru%20Guru%20Onsen%20BB%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Atsumare!%20Guru%20Guru%20Onsen%20BB.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000480000 and rom copier for roms/sdc/Atsumare! Guru Guru Onsen BB.chd"
   },
   "05500000004B0000": {
     "id": "05500000004B0000",
     "name": "Atsumare! Guru Guru Onsen Demo 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Atsumare!%20Guru%20Guru%20Onsen%20BB%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Atsumare!%20Guru%20Guru%20Onsen%20BB.png",
     "region": "US",
     "description": "Forwarder installer for 05500000004a0000 and rom copier for roms/sdc/Atsumare! Guru Guru Onsen Demo 2.chd"
   },
   "05500000004D0000": {
     "id": "05500000004D0000",
     "name": "Atsumare! Guru Guru Onsen Demo [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Atsumare!%20Guru%20Guru%20Onsen%20BB%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Atsumare!%20Guru%20Guru%20Onsen%20BB.png",
     "region": "US",
     "description": "Forwarder installer for 05500000004c0000 and rom copier for roms/sdc/Atsumare! Guru Guru Onsen Demo.chd"
   },
   "05500000004F0000": {
     "id": "05500000004F0000",
     "name": "Atsumare! Guru Guru Onsen [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Atsumare!%20Guru%20Guru%20Onsen%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Atsumare!%20Guru%20Guru%20Onsen.png",
     "region": "US",
     "description": "Forwarder installer for 05500000004e0000 and rom copier for roms/sdc/Atsumare! Guru Guru Onsen.chd"
   },
   "0550000000510000": {
     "id": "0550000000510000",
     "name": "Bakumatsu Roman Daini Maku - Gekka no Kenshi - Final Edition [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Bakumatsu%20Roman%20Daini%20Maku%20-%20Gekka%20no%20Kenshi%20-%20Final%20Edition%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Bakumatsu%20Roman%20Daini%20Maku%20-%20Gekka%20no%20Kenshi%20-%20Final%20Edition.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000500000 and rom copier for roms/sdc/Bakumatsu Roman Daini Maku - Gekka no Kenshi - Final Edition.chd"
   },
   "0550000000530000": {
     "id": "0550000000530000",
     "name": "Bakuretsu Muteki Bangaioh [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Bakuretsu%20Muteki%20Bangaioh%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Bakuretsu%20Muteki%20Bangaioh.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000520000 and rom copier for roms/sdc/Bakuretsu Muteki Bangaioh.chd"
   },
   "0550000000550000": {
     "id": "0550000000550000",
     "name": "Baldr Force EXE [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Baldr%20Force%20EXE%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Baldr%20Force%20EXE.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000540000 and rom copier for roms/sdc/Baldr Force EXE.chd"
   },
   "0550000000570000": {
     "id": "0550000000570000",
     "name": "Bang! Gunship Elite [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Bang!%20Gunship%20Elite%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Bang!%20Gunship%20Elite.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000560000 and rom copier for roms/sdc/Bang! Gunship Elite.chd"
   },
   "0550000000590000": {
     "id": "0550000000590000",
     "name": "Bangai-O [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Bangai-O%20(Europe)%20(En,Fr,De).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Bangai-O.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000580000 and rom copier for roms/sdc/Bangai-O.chd"
   },
   "05500000005B0000": {
     "id": "05500000005B0000",
     "name": "Bass Rush Dream - EcoGear PowerWorm Championship [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Bass%20Rush%20Dream%20-%20EcoGear%20PowerWorm%20Championship%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Bass%20Rush%20Dream%20-%20EcoGear%20PowerWorm%20Championship.png",
     "region": "US",
     "description": "Forwarder installer for 05500000005a0000 and rom copier for roms/sdc/Bass Rush Dream - EcoGear PowerWorm Championship.chd"
   },
   "05500000005D0000": {
     "id": "05500000005D0000",
     "name": "Battle Beaster [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Battle%20Beaster%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Battle%20Beaster.png",
     "region": "US",
     "description": "Forwarder installer for 05500000005c0000 and rom copier for roms/sdc/Battle Beaster.chd"
   },
   "05500000005F0000": {
     "id": "05500000005F0000",
     "name": "Berserk - Millennium Falcon-hen - Wasurebana no Shou Taikenban [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Berserk%20-%20Millennium%20Falcon-hen%20-%20Wasurebana%20no%20Shou%20(Japan)%20(Taikenban).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Berserk%20-%20Millennium%20Falcon-hen%20-%20Wasurebana%20no%20Shou.png",
     "region": "US",
     "description": "Forwarder installer for 05500000005e0000 and rom copier for roms/sdc/Berserk - Millennium Falcon-hen - Wasurebana no Shou Taikenban.chd"
   },
   "0550000000610000": {
     "id": "0550000000610000",
     "name": "Berserk - Millennium Falcon-hen - Wasurebana no Shou [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Berserk%20-%20Millennium%20Falcon-hen%20-%20Wasurebana%20no%20Shou%20(Japan)%20(Taikenban).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Berserk%20-%20Millennium%20Falcon-hen%20-%20Wasurebana%20no%20Shou.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000600000 and rom copier for roms/sdc/Berserk - Millennium Falcon-hen - Wasurebana no Shou.chd"
   },
   "0550000000630000": {
     "id": "0550000000630000",
     "name": "BikkuriMan 2000 - Viva! Festiva! [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/BikkuriMan%202000%20-%20Viva!%20Festiva!%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/BikkuriMan%202000%20-%20Viva!%20Festiva!.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000620000 and rom copier for roms/sdc/BikkuriMan 2000 - Viva! Festiva!.chd"
   },
   "0550000000650000": {
     "id": "0550000000650000",
     "name": "Biohazard - Code - Veronica - Kanzenban Disc #1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Biohazard%20-%20Code%20-%20Veronica%20-%20Kanzenban%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Biohazard%20-%20Code%20-%20Veronica%20-%20Kanzenban%20Disc%20%231.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000640000 and rom copier for roms/sdc/Biohazard - Code - Veronica - Kanzenban Disc #1.chd"
   },
   "0550000000670000": {
     "id": "0550000000670000",
     "name": "Biohazard - Code - Veronica - Kanzenban Disc #2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Biohazard%20-%20Code%20-%20Veronica%20-%20Kanzenban%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Biohazard%20-%20Code%20-%20Veronica%20-%20Kanzenban%20Disc%20%232.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000660000 and rom copier for roms/sdc/Biohazard - Code - Veronica - Kanzenban Disc #2.chd"
   },
   "0550000000690000": {
     "id": "0550000000690000",
     "name": "Biohazard - Code - Veronica - Trial Edition [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Biohazard%20-%20Code%20-%20Veronica%20-%20Trial%20Edition%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Biohazard%20-%20Code%20-%20Veronica%20-%20Trial%20Edition.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000680000 and rom copier for roms/sdc/Biohazard - Code - Veronica - Trial Edition.chd"
   },
   "05500000006B0000": {
     "id": "05500000006B0000",
     "name": "Biohazard - Code - Veronica Disc #1 Genteiban [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Biohazard%20-%20Code%20-%20Veronica%20-%20Kanzenban%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Biohazard%20-%20Code%20-%20Veronica%20Disc%20%231%20Genteiban.png",
     "region": "US",
     "description": "Forwarder installer for 05500000006a0000 and rom copier for roms/sdc/Biohazard - Code - Veronica Disc #1 Genteiban.chd"
   },
   "05500000006D0000": {
     "id": "05500000006D0000",
     "name": "Biohazard - Code - Veronica Disc #1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Biohazard%20-%20Code%20-%20Veronica%20(Japan)%20(Disc%201)%20(Genteiban).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Biohazard%20-%20Code%20-%20Veronica%20Disc%20%231.png",
     "region": "US",
     "description": "Forwarder installer for 05500000006c0000 and rom copier for roms/sdc/Biohazard - Code - Veronica Disc #1.chd"
   },
   "05500000006F0000": {
     "id": "05500000006F0000",
     "name": "Biohazard - Code - Veronica Disc #2 Genteiban [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Biohazard%20-%20Code%20-%20Veronica%20-%20Kanzenban%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Biohazard%20-%20Code%20-%20Veronica%20Disc%20%232%20Genteiban.png",
     "region": "US",
     "description": "Forwarder installer for 05500000006e0000 and rom copier for roms/sdc/Biohazard - Code - Veronica Disc #2 Genteiban.chd"
   },
   "0550000000710000": {
     "id": "0550000000710000",
     "name": "Biohazard - Code - Veronica Disc #2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Biohazard%20-%20Code%20-%20Veronica%20(Japan)%20(Disc%201)%20(Genteiban).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Biohazard%20-%20Code%20-%20Veronica%20Disc%20%232.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000700000 and rom copier for roms/sdc/Biohazard - Code - Veronica Disc #2.chd"
   },
   "0550000000730000": {
     "id": "0550000000730000",
     "name": "Biohazard 2 - Value Plus Disc #1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Biohazard%202%20-%20Value%20Plus%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Biohazard%202%20-%20Value%20Plus%20Disc%20%231.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000720000 and rom copier for roms/sdc/Biohazard 2 - Value Plus Disc #1.chd"
   },
   "0550000000750000": {
     "id": "0550000000750000",
     "name": "Biohazard 2 - Value Plus Disc #2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Biohazard%202%20-%20Value%20Plus%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Biohazard%202%20-%20Value%20Plus%20Disc%20%232.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000740000 and rom copier for roms/sdc/Biohazard 2 - Value Plus Disc #2.chd"
   },
   "0550000000770000": {
     "id": "0550000000770000",
     "name": "Biohazard 3 - Last Escape [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Biohazard%203%20-%20Last%20Escape%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Biohazard%203%20-%20Last%20Escape.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000760000 and rom copier for roms/sdc/Biohazard 3 - Last Escape.chd"
   },
   "0550000000790000": {
     "id": "0550000000790000",
     "name": "Black-Matrix Advanced Disc #1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Black-Matrix%20Advanced%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Black-Matrix%20Advanced%20Disc%20%231.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000780000 and rom copier for roms/sdc/Black-Matrix Advanced Disc #1.chd"
   },
   "05500000007B0000": {
     "id": "05500000007B0000",
     "name": "Black-Matrix Advanced Disc #2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Black-Matrix%20Advanced%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Black-Matrix%20Advanced%20Disc%20%232.png",
     "region": "US",
     "description": "Forwarder installer for 05500000007a0000 and rom copier for roms/sdc/Black-Matrix Advanced Disc #2.chd"
   },
   "05500000007D0000": {
     "id": "05500000007D0000",
     "name": "Blue Stinger [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Blue%20Stinger%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Blue%20Stinger.png",
     "region": "US",
     "description": "Forwarder installer for 05500000007c0000 and rom copier for roms/sdc/Blue Stinger.chd"
   },
   "05500000007F0000": {
     "id": "05500000007F0000",
     "name": "Blue-Sky-Blue[s] - Sora o Mau Tsubasa [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Blue-Sky-Blue%5Bs%5D%20-%20Sora%20o%20Mau%20Tsubasa%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Blue-Sky-Blue%5Bs%5D%20-%20Sora%20o%20Mau%20Tsubasa.png",
     "region": "US",
     "description": "Forwarder installer for 05500000007e0000 and rom copier for roms/sdc/Blue-Sky-Blue[s] - Sora o Mau Tsubasa.chd"
   },
   "0550000000810000": {
     "id": "0550000000810000",
     "name": "Bokomu no Tatsujin [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Bokomu%20no%20Tatsujin%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Bokomu%20no%20Tatsujin.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000800000 and rom copier for roms/sdc/Bokomu no Tatsujin.chd"
   },
   "0550000000830000": {
     "id": "0550000000830000",
     "name": "Boku Doraemon [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Boku%20Doraemon%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Boku%20Doraemon.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000820000 and rom copier for roms/sdc/Boku Doraemon.chd"
   },
   "0550000000850000": {
     "id": "0550000000850000",
     "name": "Boku no Tennis Jinsei [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Boku%20no%20Tennis%20Jinsei%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Boku%20no%20Tennis%20Jinsei.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000840000 and rom copier for roms/sdc/Boku no Tennis Jinsei.chd"
   },
   "0550000000870000": {
     "id": "0550000000870000",
     "name": "Boku to, Bokura no Natsu [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Boku%20to,%20Bokura%20no%20Natsu%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Boku%20to,%20Bokura%20no%20Natsu.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000860000 and rom copier for roms/sdc/Boku to, Bokura no Natsu.chd"
   },
   "0550000000890000": {
     "id": "0550000000890000",
     "name": "Bomber Hehhe! [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Bomber%20Hehhe!%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Bomber%20Hehhe!.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000880000 and rom copier for roms/sdc/Bomber Hehhe!.chd"
   },
   "05500000008B0000": {
     "id": "05500000008B0000",
     "name": "Bomberman Online [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Bomberman%20Online%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Bomberman%20Online.png",
     "region": "US",
     "description": "Forwarder installer for 05500000008a0000 and rom copier for roms/sdc/Bomberman Online.chd"
   },
   "05500000008D0000": {
     "id": "05500000008D0000",
     "name": "Border Down [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Border%20Down%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Border%20Down.png",
     "region": "US",
     "description": "Forwarder installer for 05500000008c0000 and rom copier for roms/sdc/Border Down.chd"
   },
   "05500000008F0000": {
     "id": "05500000008F0000",
     "name": "Bounty Hunter Sara - Holy Mountain no Teiou [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Bounty%20Hunter%20Sara%20-%20Holy%20Mountain%20no%20Teiou%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Bounty%20Hunter%20Sara%20-%20Holy%20Mountain%20no%20Teiou.png",
     "region": "US",
     "description": "Forwarder installer for 05500000008e0000 and rom copier for roms/sdc/Bounty Hunter Sara - Holy Mountain no Teiou.chd"
   },
   "0550000000910000": {
     "id": "0550000000910000",
     "name": "Broadband Passport [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000900000 and rom copier for roms/sdc/Broadband Passport.chd"
   },
   "0550000000930000": {
     "id": "0550000000930000",
     "name": "Buggy Heat [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Buggy%20Heat%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Buggy%20Heat.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000920000 and rom copier for roms/sdc/Buggy Heat.chd"
   },
   "0550000000950000": {
     "id": "0550000000950000",
     "name": "Bust-A-Move 4 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Bust-A-Move%204%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Bust-A-Move%204.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000940000 and rom copier for roms/sdc/Bust-A-Move 4.chd"
   },
   "0550000000970000": {
     "id": "0550000000970000",
     "name": "Caesars Palace 2000 - Millennium Gold Edition [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Caesars%20Palace%202000%20-%20Millennium%20Gold%20Edition%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Caesars%20Palace%202000%20-%20Millennium%20Gold%20Edition.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000960000 and rom copier for roms/sdc/Caesars Palace 2000 - Millennium Gold Edition.chd"
   },
   "0550000000990000": {
     "id": "0550000000990000",
     "name": "Cafe Little Wish [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Cafe%20Little%20Wish%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Cafe%20Little%20Wish.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000980000 and rom copier for roms/sdc/Cafe Little Wish.chd"
   },
   "05500000009B0000": {
     "id": "05500000009B0000",
     "name": "Canary - Kono Omoi o Uta ni Nosete [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Canary%20-%20Kono%20Omoi%20o%20Uta%20ni%20Nosete%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Canary%20-%20Kono%20Omoi%20o%20Uta%20ni%20Nosete.png",
     "region": "US",
     "description": "Forwarder installer for 05500000009a0000 and rom copier for roms/sdc/Canary - Kono Omoi o Uta ni Nosete.chd"
   },
   "05500000009D0000": {
     "id": "05500000009D0000",
     "name": "Candy Stripe - Minarai Tenshi [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Candy%20Stripe%20-%20Minarai%20Tenshi%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Candy%20Stripe%20-%20Minarai%20Tenshi.png",
     "region": "US",
     "description": "Forwarder installer for 05500000009c0000 and rom copier for roms/sdc/Candy Stripe - Minarai Tenshi.chd"
   },
   "05500000009F0000": {
     "id": "05500000009F0000",
     "name": "Cannon Spike [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Cannon%20Spike%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Cannon%20Spike.png",
     "region": "US",
     "description": "Forwarder installer for 05500000009e0000 and rom copier for roms/sdc/Cannon Spike.chd"
   },
   "0550000000A10000": {
     "id": "0550000000A10000",
     "name": "Canvas - Sepia Iro no Motif [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Canvas%20-%20Sepia%20Iro%20no%20Motif%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Canvas%20-%20Sepia%20Iro%20no%20Motif.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000a00000 and rom copier for roms/sdc/Canvas - Sepia Iro no Motif.chd"
   },
   "0550000000A30000": {
     "id": "0550000000A30000",
     "name": "Capcom Taisen Fan Disc [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Capcom%20Taisen%20Fan%20Disc%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Capcom%20Taisen%20Fan%20Disc.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000a20000 and rom copier for roms/sdc/Capcom Taisen Fan Disc.chd"
   },
   "0550000000A50000": {
     "id": "0550000000A50000",
     "name": "Capcom vs. SNK - Millennium Fight 2000 Pro [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Capcom%20vs.%20SNK%20-%20Millennium%20Fight%202000%20Pro%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Capcom%20vs.%20SNK%20-%20Millennium%20Fight%202000%20Pro.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000a40000 and rom copier for roms/sdc/Capcom vs. SNK - Millennium Fight 2000 Pro.chd"
   },
   "0550000000A70000": {
     "id": "0550000000A70000",
     "name": "Capcom vs. SNK - Millennium Fight 2000 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Capcom%20vs.%20SNK%20-%20Millennium%20Fight%202000%20(Japan)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Capcom%20vs.%20SNK%20-%20Millennium%20Fight%202000.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000a60000 and rom copier for roms/sdc/Capcom vs. SNK - Millennium Fight 2000.chd"
   },
   "0550000000A90000": {
     "id": "0550000000A90000",
     "name": "Capcom vs. SNK 2 - Millionaire Fighting 2001 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Capcom%20vs.%20SNK%202%20-%20Millionaire%20Fighting%202001%20(Japan)%20-%20(Disc%201%20of%202).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Capcom%20vs.%20SNK%202%20-%20Millionaire%20Fighting%202001.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000a80000 and rom copier for roms/sdc/Capcom vs. SNK 2 - Millionaire Fighting 2001.chd"
   },
   "0550000000AB0000": {
     "id": "0550000000AB0000",
     "name": "Capcom vs. SNK [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Capcom%20vs.%20SNK%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Capcom%20vs.%20SNK.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000aa0000 and rom copier for roms/sdc/Capcom vs. SNK.chd"
   },
   "0550000000AD0000": {
     "id": "0550000000AD0000",
     "name": "Card of Destiny - Hikari to Yami no Tougousha [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Card%20of%20Destiny%20-%20Hikari%20to%20Yami%20no%20Tougousha%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Card%20of%20Destiny%20-%20Hikari%20to%20Yami%20no%20Tougousha.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000ac0000 and rom copier for roms/sdc/Card of Destiny - Hikari to Yami no Tougousha.chd"
   },
   "0550000000AF0000": {
     "id": "0550000000AF0000",
     "name": "Cardcaptor Sakura - Tomoyo no Video Daisakusen [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Cardcaptor%20Sakura%20-%20Tomoyo%20no%20Video%20Daisakusen%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Cardcaptor%20Sakura%20-%20Tomoyo%20no%20Video%20Daisakusen.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000ae0000 and rom copier for roms/sdc/Cardcaptor Sakura - Tomoyo no Video Daisakusen.chd"
   },
   "0550000000B10000": {
     "id": "0550000000B10000",
     "name": "Carrier [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Carrier%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Carrier.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000b00000 and rom copier for roms/sdc/Carrier.chd"
   },
   "0550000000B30000": {
     "id": "0550000000B30000",
     "name": "Castle Fantasia - Seima Taisen [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Castle%20Fantasia%20-%20Seima%20Taisen%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Castle%20Fantasia%20-%20Seima%20Taisen.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000b20000 and rom copier for roms/sdc/Castle Fantasia - Seima Taisen.chd"
   },
   "0550000000B50000": {
     "id": "0550000000B50000",
     "name": "Centipede [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Centipede%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Centipede.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000b40000 and rom copier for roms/sdc/Centipede.chd"
   },
   "0550000000B70000": {
     "id": "0550000000B70000",
     "name": "Championship Surfer [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Championship%20Surfer%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Championship%20Surfer.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000b60000 and rom copier for roms/sdc/Championship Surfer.chd"
   },
   "0550000000B90000": {
     "id": "0550000000B90000",
     "name": "Chaos Field [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Chaos%20Field%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Chaos%20Field.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000b80000 and rom copier for roms/sdc/Chaos Field.chd"
   },
   "0550000000BB0000": {
     "id": "0550000000BB0000",
     "name": "Charge 'N Blast [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Charge%20'N%20Blast%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Charge%20'N%20Blast.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000ba0000 and rom copier for roms/sdc/Charge 'N Blast.chd"
   },
   "0550000000BD0000": {
     "id": "0550000000BD0000",
     "name": "Cherry Blossom [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Cherry%20Blossom%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Cherry%20Blossom.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000bc0000 and rom copier for roms/sdc/Cherry Blossom.chd"
   },
   "0550000000BF0000": {
     "id": "0550000000BF0000",
     "name": "Chicken Run [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Chicken%20Run%20(Europe)%20(Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Chicken%20Run.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000be0000 and rom copier for roms/sdc/Chicken Run.chd"
   },
   "0550000000C10000": {
     "id": "0550000000C10000",
     "name": "Chocolat - Maid Cafe Curio Demo [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Chocolat%20-%20Maid%20Cafe%20Curio%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Chocolat%20-%20Maid%20Cafe%20Curio.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000c00000 and rom copier for roms/sdc/Chocolat - Maid Cafe Curio Demo.chd"
   },
   "0550000000C30000": {
     "id": "0550000000C30000",
     "name": "Chocolat - Maid Cafe Curio [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Chocolat%20-%20Maid%20Cafe%20Curio%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Chocolat%20-%20Maid%20Cafe%20Curio.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000c20000 and rom copier for roms/sdc/Chocolat - Maid Cafe Curio.chd"
   },
   "0550000000C50000": {
     "id": "0550000000C50000",
     "name": "Chou Hatsumei Boy Kanipan - Bousou Robot no Nazo! [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Chou%20Hatsumei%20Boy%20Kanipan%20-%20Bousou%20Robot%20no%20Nazo!%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Chou%20Hatsumei%20Boy%20Kanipan%20-%20Bousou%20Robot%20no%20Nazo!.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000c40000 and rom copier for roms/sdc/Chou Hatsumei Boy Kanipan - Bousou Robot no Nazo!.chd"
   },
   "0550000000C70000": {
     "id": "0550000000C70000",
     "name": "Choukou Senki Kikaioh for Matching Service [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Choukou%20Senki%20Kikaioh%20for%20Matching%20Service%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Choukou%20Senki%20Kikaioh%20for%20Matching%20Service.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000c60000 and rom copier for roms/sdc/Choukou Senki Kikaioh for Matching Service.chd"
   },
   "0550000000C90000": {
     "id": "0550000000C90000",
     "name": "Choukou Senki Kikaioh [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Choukou%20Senki%20Kikaioh%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Choukou%20Senki%20Kikaioh.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000c80000 and rom copier for roms/sdc/Choukou Senki Kikaioh.chd"
   },
   "0550000000CB0000": {
     "id": "0550000000CB0000",
     "name": "Christmas Seaman - Omoi o Tsutaeru Mou Hitotsu no Houhou Message Disc [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Christmas%20Seaman%20-%20Omoi%20o%20Tsutaeru%20Mou%20Hitotsu%20no%20Houhou%20(Japan)%20(Message%20Disc).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Christmas%20Seaman%20-%20Omoi%20o%20Tsutaeru%20Mou%20Hitotsu%20no%20Houhou%20Message%20Disc.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000ca0000 and rom copier for roms/sdc/Christmas Seaman - Omoi o Tsutaeru Mou Hitotsu no Houhou Message Disc.chd"
   },
   "0550000000CD0000": {
     "id": "0550000000CD0000",
     "name": "Christmas Seaman - Omoi o Tsutaeru Mou Hitotsu no Houhou Present Disc [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Christmas%20Seaman%20-%20Omoi%20o%20Tsutaeru%20Mou%20Hitotsu%20no%20Houhou%20(Japan)%20(Message%20Disc).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Christmas%20Seaman%20-%20Omoi%20o%20Tsutaeru%20Mou%20Hitotsu%20no%20Houhou%20Present%20Disc.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000cc0000 and rom copier for roms/sdc/Christmas Seaman - Omoi o Tsutaeru Mou Hitotsu no Houhou Present Disc.chd"
   },
   "0550000000CF0000": {
     "id": "0550000000CF0000",
     "name": "Chu-Chu Rocket! Taikenban [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Chu-Chu%20Rocket!%20(Japan)%20(Taikenban).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Chu-Chu%20Rocket!%20Taikenban.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000ce0000 and rom copier for roms/sdc/Chu-Chu Rocket! Taikenban.chd"
   },
   "0550000000D10000": {
     "id": "0550000000D10000",
     "name": "ChuChu Rocket! [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/ChuChu%20Rocket!%20(Europe)%20(En,Ja,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/ChuChu%20Rocket!.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000d00000 and rom copier for roms/sdc/ChuChu Rocket!.chd"
   },
   "0550000000D30000": {
     "id": "0550000000D30000",
     "name": "Cleopatra Fortune [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Cleopatra%20Fortune%20(Japan)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Cleopatra%20Fortune.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000d20000 and rom copier for roms/sdc/Cleopatra Fortune.chd"
   },
   "0550000000D50000": {
     "id": "0550000000D50000",
     "name": "Climax Landers [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Climax%20Landers%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Climax%20Landers.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000d40000 and rom copier for roms/sdc/Climax Landers.chd"
   },
   "0550000000D70000": {
     "id": "0550000000D70000",
     "name": "Close To - Inori no Oka [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Close%20To%20-%20Inori%20no%20Oka%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Close%20To%20-%20Inori%20no%20Oka.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000d60000 and rom copier for roms/sdc/Close To - Inori no Oka.chd"
   },
   "0550000000D90000": {
     "id": "0550000000D90000",
     "name": "Coaster Works [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Coaster%20Works%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Coaster%20Works.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000d80000 and rom copier for roms/sdc/Coaster Works.chd"
   },
   "0550000000DB0000": {
     "id": "0550000000DB0000",
     "name": "Comic Party Disc #1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Comic%20Party%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://github.com/teknik-app/forwarder-images/blob/main/sdc/Comic%20Party%20Disc%20%231.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000da0000 and rom copier for roms/sdc/Comic Party Disc #1.chd"
   },
   "0550000000DD0000": {
     "id": "0550000000DD0000",
     "name": "Comic Party Disc #2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Comic%20Party%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Comic%20Party%20Disc%20%232.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000dc0000 and rom copier for roms/sdc/Comic Party Disc #2.chd"
   },
   "0550000000DF0000": {
     "id": "0550000000DF0000",
     "name": "Confidential Mission [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Confidential%20Mission%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Confidential%20Mission.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000de0000 and rom copier for roms/sdc/Confidential Mission.chd"
   },
   "0550000000E10000": {
     "id": "0550000000E10000",
     "name": "Conflict Zone [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Conflict%20Zone%20(Europe)%20(En,Fr,De).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Conflict%20Zone.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000e00000 and rom copier for roms/sdc/Conflict Zone.chd"
   },
   "0550000000E30000": {
     "id": "0550000000E30000",
     "name": "Cool Boarders Burrrn! [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Cool%20Boarders%20Burrrn!%20(Japan)%20(Taikenban).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Cool%20Boarders%20Burrrn!.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000e20000 and rom copier for roms/sdc/Cool Boarders Burrrn!.chd"
   },
   "0550000000E50000": {
     "id": "0550000000E50000",
     "name": "Cool Cool Toon [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Cool%20Cool%20Toon%20(Japan)%20(Tentou-you%20Taikenban).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Cool%20Cool%20Toon.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000e40000 and rom copier for roms/sdc/Cool Cool Toon.chd"
   },
   "0550000000E70000": {
     "id": "0550000000E70000",
     "name": "Cosmic Smash [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Cosmic%20Smash%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Cosmic%20Smash.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000e60000 and rom copier for roms/sdc/Cosmic Smash.chd"
   },
   "0550000000E90000": {
     "id": "0550000000E90000",
     "name": "CR Hissatsu Shigotonin - Pachitte Chonmage @ VP@CHI [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/CR%20Hissatsu%20Shigotonin%20-%20Pachitte%20Chonmage%20@%20VP@CHI%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/CR%20Hissatsu%20Shigotonin%20-%20Pachitte%20Chonmage%20@%20VP@CHI.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000e80000 and rom copier for roms/sdc/CR Hissatsu Shigotonin - Pachitte Chonmage @ VP@CHI.chd"
   },
   "0550000000EB0000": {
     "id": "0550000000EB0000",
     "name": "Crazy Taxi 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Crazy%20Taxi%202%20(Europe)%20(En,Ja,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Crazy%20Taxi%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000ea0000 and rom copier for roms/sdc/Crazy Taxi 2.chd"
   },
   "0550000000ED0000": {
     "id": "0550000000ED0000",
     "name": "Crazy Taxi [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Crazy%20Taxi%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Crazy%20Taxi.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000ec0000 and rom copier for roms/sdc/Crazy Taxi.chd"
   },
   "0550000000EF0000": {
     "id": "0550000000EF0000",
     "name": "Culdcept II [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Culdcept%20II%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Culdcept%20II.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000ee0000 and rom copier for roms/sdc/Culdcept II.chd"
   },
   "0550000000F10000": {
     "id": "0550000000F10000",
     "name": "Cyber Troopers - Virtual-On - Oratorio Tangram [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Cyber%20Troopers%20-%20Virtual-On%20-%20Oratorio%20Tangram%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Cyber%20Troopers%20-%20Virtual-On%20-%20Oratorio%20Tangram.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000f00000 and rom copier for roms/sdc/Cyber Troopers - Virtual-On - Oratorio Tangram.chd"
   },
   "0550000000F30000": {
     "id": "0550000000F30000",
     "name": "D+Vine [Luv] [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/D+Vine%20%5BLuv%5D%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/D+Vine%20%5BLuv%5D.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000f20000 and rom copier for roms/sdc/D+Vine [Luv].chd"
   },
   "0550000000F50000": {
     "id": "0550000000F50000",
     "name": "D2 Disc #1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/D2%20Shock%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/D2%20Shock.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000f40000 and rom copier for roms/sdc/D2 Disc #1.chd"
   },
   "0550000000F70000": {
     "id": "0550000000F70000",
     "name": "D2 Disc #2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/D2%20Shock%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/D2%20Shock.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000f60000 and rom copier for roms/sdc/D2 Disc #2.chd"
   },
   "0550000000F90000": {
     "id": "0550000000F90000",
     "name": "D2 Disc #3 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/D2%20Shock%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/D2%20Shock.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000f80000 and rom copier for roms/sdc/D2 Disc #3.chd"
   },
   "0550000000FB0000": {
     "id": "0550000000FB0000",
     "name": "D2 Disc #4 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/D2%20Shock%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/D2%20Shock.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000fa0000 and rom copier for roms/sdc/D2 Disc #4.chd"
   },
   "0550000000FD0000": {
     "id": "0550000000FD0000",
     "name": "D2 Shock [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/D2%20Shock%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/D2%20Shock.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000fc0000 and rom copier for roms/sdc/D2 Shock.chd"
   },
   "0550000000FF0000": {
     "id": "0550000000FF0000",
     "name": "Dance Dance Revolution - Club Version - Dreamcast Edition [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dance%20Dance%20Revolution%20-%20Club%20Version%20-%20Dreamcast%20Edition%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dance%20Dance%20Revolution%20-%20Club%20Version%20-%20Dreamcast%20Edition.png",
     "region": "US",
     "description": "Forwarder installer for 0550000000fe0000 and rom copier for roms/sdc/Dance Dance Revolution - Club Version - Dreamcast Edition.chd"
   },
   "0550000001010000": {
     "id": "0550000001010000",
     "name": "Dance Dance Revolution 2nd Mix - Dreamcast Edition [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dance%20Dance%20Revolution%202nd%20Mix%20-%20Dreamcast%20Edition%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dance%20Dance%20Revolution%202nd%20Mix%20-%20Dreamcast%20Edition.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001000000 and rom copier for roms/sdc/Dance Dance Revolution 2nd Mix - Dreamcast Edition.chd"
   },
   "0550000001030000": {
     "id": "0550000001030000",
     "name": "Dancing Blade Katte ni Momotenshi II - Tears of Eden Kanzenban Disc #1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dancing%20Blade%20Katte%20ni%20Momotenshi%20II%20-%20Tears%20of%20Eden%20Kanzenban%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dancing%20Blade%20Katte%20ni%20Momotenshi%20II%20-%20Tears%20of%20Eden%20Kanzenban%20Disc%20%231.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001020000 and rom copier for roms/sdc/Dancing Blade Katte ni Momotenshi II - Tears of Eden Kanzenban Disc #1.chd"
   },
   "0550000001050000": {
     "id": "0550000001050000",
     "name": "Dancing Blade Katte ni Momotenshi II - Tears of Eden Kanzenban Disc #2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dancing%20Blade%20Katte%20ni%20Momotenshi%20II%20-%20Tears%20of%20Eden%20Kanzenban%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dancing%20Blade%20Katte%20ni%20Momotenshi%20II%20-%20Tears%20of%20Eden%20Kanzenban%20Disc%20%232.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001040000 and rom copier for roms/sdc/Dancing Blade Katte ni Momotenshi II - Tears of Eden Kanzenban Disc #2.chd"
   },
   "0550000001070000": {
     "id": "0550000001070000",
     "name": "Dancing Blade Katte ni Momotenshi! Kanzenban Disc #1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dancing%20Blade%20Katte%20ni%20Momotenshi!%20Kanzenban%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dancing%20Blade%20Katte%20ni%20Momotenshi!%20Kanzenban%20Disc%20%231.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001060000 and rom copier for roms/sdc/Dancing Blade Katte ni Momotenshi! Kanzenban Disc #1.chd"
   },
   "0550000001090000": {
     "id": "0550000001090000",
     "name": "Dancing Blade Katte ni Momotenshi! Kanzenban Disc #2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dancing%20Blade%20Katte%20ni%20Momotenshi!%20Kanzenban%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dancing%20Blade%20Katte%20ni%20Momotenshi!%20Kanzenban%20Disc%20%232.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001080000 and rom copier for roms/sdc/Dancing Blade Katte ni Momotenshi! Kanzenban Disc #2.chd"
   },
   "05500000010B0000": {
     "id": "05500000010B0000",
     "name": "Dave Mirra Freestyle BMX [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dave%20Mirra%20Freestyle%20BMX%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dave%20Mirra%20Freestyle%20BMX.png",
     "region": "US",
     "description": "Forwarder installer for 05500000010a0000 and rom copier for roms/sdc/Dave Mirra Freestyle BMX.chd"
   },
   "05500000010D0000": {
     "id": "05500000010D0000",
     "name": "Daytona USA [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Daytona%20USA%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Daytona%20USA.png",
     "region": "US",
     "description": "Forwarder installer for 05500000010c0000 and rom copier for roms/sdc/Daytona USA.chd"
   },
   "05500000010F0000": {
     "id": "05500000010F0000",
     "name": "De La Jet Set Radio [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/De%20La%20Jet%20Set%20Radio%20(Japan)%20(En,Ja,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/De%20La%20Jet%20Set%20Radio.png",
     "region": "US",
     "description": "Forwarder installer for 05500000010e0000 and rom copier for roms/sdc/De La Jet Set Radio.chd"
   },
   "0550000001110000": {
     "id": "0550000001110000",
     "name": "Dead or Alive 2 Beta [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dead%20or%20Alive%202%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dead%20or%20Alive%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001100000 and rom copier for roms/sdc/Dead or Alive 2 Beta.chd"
   },
   "0550000001130000": {
     "id": "0550000001130000",
     "name": "Dead or Alive 2 Demo [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dead%20or%20Alive%202%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dead%20or%20Alive%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001120000 and rom copier for roms/sdc/Dead or Alive 2 Demo.chd"
   },
   "0550000001150000": {
     "id": "0550000001150000",
     "name": "Dead or Alive 2 Shokai Genteiban [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dead%20or%20Alive%202%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dead%20or%20Alive%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001140000 and rom copier for roms/sdc/Dead or Alive 2 Shokai Genteiban.chd"
   },
   "0550000001170000": {
     "id": "0550000001170000",
     "name": "Dead or Alive 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dead%20or%20Alive%202%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dead%20or%20Alive%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001160000 and rom copier for roms/sdc/Dead or Alive 2.chd"
   },
   "0550000001190000": {
     "id": "0550000001190000",
     "name": "Deadly Skies [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Deadly%20Skies%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Deadly%20Skies.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001180000 and rom copier for roms/sdc/Deadly Skies.chd"
   },
   "05500000011B0000": {
     "id": "05500000011B0000",
     "name": "Death Crimson 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Death%20Crimson%202%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Death%20Crimson%202.png",
     "region": "US",
     "description": "Forwarder installer for 05500000011a0000 and rom copier for roms/sdc/Death Crimson 2.chd"
   },
   "05500000011D0000": {
     "id": "05500000011D0000",
     "name": "Death Crimson OX [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Death%20Crimson%20OX%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Death%20Crimson%20OX.png",
     "region": "US",
     "description": "Forwarder installer for 05500000011c0000 and rom copier for roms/sdc/Death Crimson OX.chd"
   },
   "05500000011F0000": {
     "id": "05500000011F0000",
     "name": "Deep Fighter Disc #1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Deep%20Fighter%20(Europe)%20(En,It)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Deep%20Fighter%20Disc%20%231.png",
     "region": "US",
     "description": "Forwarder installer for 05500000011e0000 and rom copier for roms/sdc/Deep Fighter Disc #1.chd"
   },
   "0550000001210000": {
     "id": "0550000001210000",
     "name": "Deep Fighter Disc #2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Deep%20Fighter%20(Europe)%20(En,It)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Deep%20Fighter%20Disc%20%232.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001200000 and rom copier for roms/sdc/Deep Fighter Disc #2.chd"
   },
   "0550000001230000": {
     "id": "0550000001230000",
     "name": "Dejiko no Maibura [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dejiko%20no%20Maibura%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dejiko%20no%20Maibura.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001220000 and rom copier for roms/sdc/Dejiko no Maibura.chd"
   },
   "0550000001250000": {
     "id": "0550000001250000",
     "name": "Demolition Racer - No Exit Demo [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Demolition%20Racer%20-%20No%20Exit%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Demolition%20Racer%20-%20No%20Exit.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001240000 and rom copier for roms/sdc/Demolition Racer - No Exit Demo.chd"
   },
   "0550000001270000": {
     "id": "0550000001270000",
     "name": "Demolition Racer - No Exit [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Demolition%20Racer%20-%20No%20Exit%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Demolition%20Racer%20-%20No%20Exit.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001260000 and rom copier for roms/sdc/Demolition Racer - No Exit.chd"
   },
   "0550000001290000": {
     "id": "0550000001290000",
     "name": "Dengen Tenshi Taisen Mahjong Shangri-La [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dengen%20Tenshi%20Taisen%20Mahjong%20Shangri-La%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dengen%20Tenshi%20Taisen%20Mahjong%20Shangri-La.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001280000 and rom copier for roms/sdc/Dengen Tenshi Taisen Mahjong Shangri-La.chd"
   },
   "05500000012B0000": {
     "id": "05500000012B0000",
     "name": "Dennou Senki - Virtual-On - Oratorio Tangram [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dennou%20Senki%20-%20Virtual-On%20-%20Oratorio%20Tangram%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dennou%20Senki%20-%20Virtual-On%20-%20Oratorio%20Tangram.png",
     "region": "US",
     "description": "Forwarder installer for 05500000012a0000 and rom copier for roms/sdc/Dennou Senki - Virtual-On - Oratorio Tangram.chd"
   },
   "05500000012D0000": {
     "id": "05500000012D0000",
     "name": "Denpa Shounen-teki Kenshou Seikatsu Soft - Nasubi no Heya [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Denpa%20Shounen-teki%20Kenshou%20Seikatsu%20Soft%20-%20Nasubi%20no%20Heya%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Denpa%20Shounen-teki%20Kenshou%20Seikatsu%20Soft%20-%20Nasubi%20no%20Heya.png",
     "region": "US",
     "description": "Forwarder installer for 05500000012c0000 and rom copier for roms/sdc/Denpa Shounen-teki Kenshou Seikatsu Soft - Nasubi no Heya.chd"
   },
   "05500000012F0000": {
     "id": "05500000012F0000",
     "name": "Densha de Go! 2 - Kousoku-hen 3000 Bandai [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Densha%20de%20Go!%202%20-%20Kousoku-hen%203000%20Bandai%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Densha%20de%20Go!%202%20-%20Kousoku-hen%203000%20Bandai.png",
     "region": "US",
     "description": "Forwarder installer for 05500000012e0000 and rom copier for roms/sdc/Densha de Go! 2 - Kousoku-hen 3000 Bandai.chd"
   },
   "0550000001310000": {
     "id": "0550000001310000",
     "name": "Derby Tsuku - Derby-ba o Tsukurou! Taikenban [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Derby%20Tsuku%20-%20Derby-ba%20o%20Tsukurou!%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Derby%20Tsuku%20-%20Derby-ba%20o%20Tsukurou!.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001300000 and rom copier for roms/sdc/Derby Tsuku - Derby-ba o Tsukurou! Taikenban.chd"
   },
   "0550000001330000": {
     "id": "0550000001330000",
     "name": "Derby Tsuku - Derby-ba o Tsukurou! [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Derby%20Tsuku%20-%20Derby-ba%20o%20Tsukurou!%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Derby%20Tsuku%20-%20Derby-ba%20o%20Tsukurou!.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001320000 and rom copier for roms/sdc/Derby Tsuku - Derby-ba o Tsukurou!.chd"
   },
   "0550000001350000": {
     "id": "0550000001350000",
     "name": "Derby Tsuku 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Crazy%20Taxi%202%20(Europe)%20(En,Ja,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Crazy%20Taxi%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001340000 and rom copier for roms/sdc/Derby Tsuku 2.chd"
   },
   "0550000001370000": {
     "id": "0550000001370000",
     "name": "deSPIRIA [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/deSPIRIA%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/deSPIRIA.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001360000 and rom copier for roms/sdc/deSPIRIA.chd"
   },
   "0550000001390000": {
     "id": "0550000001390000",
     "name": "Di Gi Charat Fantasy [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Di%20Gi%20Charat%20Fantasy%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Di%20Gi%20Charat%20Fantasy.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001380000 and rom copier for roms/sdc/Di Gi Charat Fantasy.chd"
   },
   "05500000013B0000": {
     "id": "05500000013B0000",
     "name": "Digital Keiba Shinbun - My Trackman [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Digital%20Keiba%20Shinbun%20-%20My%20Trackman%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Digital%20Keiba%20Shinbun%20-%20My%20Trackman.png",
     "region": "US",
     "description": "Forwarder installer for 05500000013a0000 and rom copier for roms/sdc/Digital Keiba Shinbun - My Trackman.chd"
   },
   "05500000013D0000": {
     "id": "05500000013D0000",
     "name": "Dino Crisis [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dino%20Crisis%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dino%20Crisis.png",
     "region": "US",
     "description": "Forwarder installer for 05500000013c0000 and rom copier for roms/sdc/Dino Crisis.chd"
   },
   "05500000013F0000": {
     "id": "05500000013F0000",
     "name": "Disney's 102 Dalmatians - Puppies to the Rescue [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Disney's%20102%20Dalmatians%20-%20Puppies%20to%20the%20Rescue%20(Europe)%20(Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Disney's%20102%20Dalmatians%20-%20Puppies%20to%20the%20Rescue.png",
     "region": "US",
     "description": "Forwarder installer for 05500000013e0000 and rom copier for roms/sdc/Disney's 102 Dalmatians - Puppies to the Rescue.chd"
   },
   "0550000001410000": {
     "id": "0550000001410000",
     "name": "Disney's Dinosaur [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Disney's%20Dinosaur%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Disney's%20Dinosaur.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001400000 and rom copier for roms/sdc/Disney's Dinosaur.chd"
   },
   "0550000001430000": {
     "id": "0550000001430000",
     "name": "Disney's Donald Duck - Goin' Quackers [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Disney's%20Donald%20Duck%20-%20Goin'%20Quackers%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Disney's%20Donald%20Duck%20-%20Goin'%20Quackers.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001420000 and rom copier for roms/sdc/Disney's Donald Duck - Goin' Quackers.chd"
   },
   "0550000001450000": {
     "id": "0550000001450000",
     "name": "Disney's Donald Duck - Quack Attack [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Disney's%20Donald%20Duck%20-%20Quack%20Attack%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Disney's%20Donald%20Duck%20-%20Quack%20Attack.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001440000 and rom copier for roms/sdc/Disney's Donald Duck - Quack Attack.chd"
   },
   "0550000001470000": {
     "id": "0550000001470000",
     "name": "Disney-Pixar Buzz Lightyear of Star Command [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Disney-Pixar%20Buzz%20Lightyear%20of%20Star%20Command%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Disney-Pixar%20Buzz%20Lightyear%20of%20Star%20Command.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001460000 and rom copier for roms/sdc/Disney-Pixar Buzz Lightyear of Star Command.chd"
   },
   "0550000001490000": {
     "id": "0550000001490000",
     "name": "Disney-Pixar Toy Story 2 - Buzz Lightyear to the Rescue! [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Disney-Pixar%20Toy%20Story%202%20-%20Buzz%20Lightyear%20to%20the%20Rescue!%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Disney-Pixar%20Toy%20Story%202%20-%20Buzz%20Lightyear%20to%20the%20Rescue!.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001480000 and rom copier for roms/sdc/Disney-Pixar Toy Story 2 - Buzz Lightyear to the Rescue!.chd"
   },
   "05500000014B0000": {
     "id": "05500000014B0000",
     "name": "Doguu Senki - Haou [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Doguu%20Senki%20-%20Haou%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Doguu%20Senki%20-%20Haou.png",
     "region": "US",
     "description": "Forwarder installer for 05500000014a0000 and rom copier for roms/sdc/Doguu Senki - Haou.chd"
   },
   "05500000014D0000": {
     "id": "05500000014D0000",
     "name": "Doki Doki Idol Star Seeker Remix [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Doki%20Doki%20Idol%20Star%20Seeker%20Remix%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Doki%20Doki%20Idol%20Star%20Seeker%20Remix.png",
     "region": "US",
     "description": "Forwarder installer for 05500000014c0000 and rom copier for roms/sdc/Doki Doki Idol Star Seeker Remix.chd"
   },
   "05500000014F0000": {
     "id": "05500000014F0000",
     "name": "Dorimaga GD Vol. 1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%201%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%201.png",
     "region": "US",
     "description": "Forwarder installer for 05500000014e0000 and rom copier for roms/sdc/Dorimaga GD Vol. 1.chd"
   },
   "0550000001510000": {
     "id": "0550000001510000",
     "name": "Dorimaga GD Vol. 10 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%2010%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%2010.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001500000 and rom copier for roms/sdc/Dorimaga GD Vol. 10.chd"
   },
   "0550000001530000": {
     "id": "0550000001530000",
     "name": "Dorimaga GD Vol. 11 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%2011%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%2011.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001520000 and rom copier for roms/sdc/Dorimaga GD Vol. 11.chd"
   },
   "0550000001550000": {
     "id": "0550000001550000",
     "name": "Dorimaga GD Vol. 12 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%2012%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%2012.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001540000 and rom copier for roms/sdc/Dorimaga GD Vol. 12.chd"
   },
   "0550000001570000": {
     "id": "0550000001570000",
     "name": "Dorimaga GD Vol. 2 Disc #1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%201%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001560000 and rom copier for roms/sdc/Dorimaga GD Vol. 2 Disc #1.chd"
   },
   "0550000001590000": {
     "id": "0550000001590000",
     "name": "Dorimaga GD Vol. 2 Disc #2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%2012%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%2012.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001580000 and rom copier for roms/sdc/Dorimaga GD Vol. 2 Disc #2.chd"
   },
   "05500000015B0000": {
     "id": "05500000015B0000",
     "name": "Dorimaga GD Vol. 3 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%203%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%203.png",
     "region": "US",
     "description": "Forwarder installer for 05500000015a0000 and rom copier for roms/sdc/Dorimaga GD Vol. 3.chd"
   },
   "05500000015D0000": {
     "id": "05500000015D0000",
     "name": "Dorimaga GD Vol. 4 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%204%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%204.png",
     "region": "US",
     "description": "Forwarder installer for 05500000015c0000 and rom copier for roms/sdc/Dorimaga GD Vol. 4.chd"
   },
   "05500000015F0000": {
     "id": "05500000015F0000",
     "name": "Dorimaga GD Vol. 5 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%205%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%205.png",
     "region": "US",
     "description": "Forwarder installer for 05500000015e0000 and rom copier for roms/sdc/Dorimaga GD Vol. 5.chd"
   },
   "0550000001610000": {
     "id": "0550000001610000",
     "name": "Dorimaga GD Vol. 6 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%206%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%206.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001600000 and rom copier for roms/sdc/Dorimaga GD Vol. 6.chd"
   },
   "0550000001630000": {
     "id": "0550000001630000",
     "name": "Dorimaga GD Vol. 7 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%207%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%207.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001620000 and rom copier for roms/sdc/Dorimaga GD Vol. 7.chd"
   },
   "0550000001650000": {
     "id": "0550000001650000",
     "name": "Dorimaga GD Vol. 8 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%208%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%208.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001640000 and rom copier for roms/sdc/Dorimaga GD Vol. 8.chd"
   },
   "0550000001670000": {
     "id": "0550000001670000",
     "name": "Dorimaga GD Vol. 9 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%209%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%209.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001660000 and rom copier for roms/sdc/Dorimaga GD Vol. 9.chd"
   },
   "0550000001690000": {
     "id": "0550000001690000",
     "name": "Dousoukai 2 - Again & Refrain [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dousoukai%202%20-%20Again%20_%20Refrain%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dousoukai%202%20-%20Again%20%26%20Refrain.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001680000 and rom copier for roms/sdc/Dousoukai 2 - Again & Refrain.chd"
   },
   "05500000016B0000": {
     "id": "05500000016B0000",
     "name": "Draconus - Cult of the Wyrm [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Draconus%20-%20Cult%20of%20the%20Wyrm%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Draconus%20-%20Cult%20of%20the%20Wyrm.png",
     "region": "US",
     "description": "Forwarder installer for 05500000016a0000 and rom copier for roms/sdc/Draconus - Cult of the Wyrm.chd"
   },
   "05500000016D0000": {
     "id": "05500000016D0000",
     "name": "Dragon Riders - Chronicles of Pern [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dragon%20Riders%20-%20Chronicles%20of%20Pern%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dragon%20Riders%20-%20Chronicles%20of%20Pern.png",
     "region": "US",
     "description": "Forwarder installer for 05500000016c0000 and rom copier for roms/sdc/Dragon Riders - Chronicles of Pern.chd"
   },
   "05500000016F0000": {
     "id": "05500000016F0000",
     "name": "Dragons Blood [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dragons%20Blood%20(Europe)%20(En,Fr,De).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dragons%20Blood.png",
     "region": "US",
     "description": "Forwarder installer for 05500000016e0000 and rom copier for roms/sdc/Dragons Blood.chd"
   },
   "0550000001710000": {
     "id": "0550000001710000",
     "name": "Dream Passport 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%202%20(Japan)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001700000 and rom copier for roms/sdc/Dream Passport 2.chd"
   },
   "0550000001730000": {
     "id": "0550000001730000",
     "name": "Dream Passport 3 - Urban Style [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%203%20-%20Urban%20Style%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%203%20-%20Urban%20Style.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001720000 and rom copier for roms/sdc/Dream Passport 3 - Urban Style.chd"
   },
   "0550000001750000": {
     "id": "0550000001750000",
     "name": "Dream Passport 3 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%203%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%203.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001740000 and rom copier for roms/sdc/Dream Passport 3.chd"
   },
   "0550000001770000": {
     "id": "0550000001770000",
     "name": "Dream Passport for Toyota [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%20for%20Toyota%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%20for%20Toyota.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001760000 and rom copier for roms/sdc/Dream Passport for Toyota.chd"
   },
   "0550000001790000": {
     "id": "0550000001790000",
     "name": "Dream Passport Premier [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%20Premier%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%20Premier.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001780000 and rom copier for roms/sdc/Dream Passport Premier.chd"
   },
   "05500000017B0000": {
     "id": "05500000017B0000",
     "name": "Dream Passport Ver.1.01 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%20Ver.1.01%20(Japan)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%20Ver.1.01.png",
     "region": "US",
     "description": "Forwarder installer for 05500000017a0000 and rom copier for roms/sdc/Dream Passport Ver.1.01.chd"
   },
   "05500000017D0000": {
     "id": "05500000017D0000",
     "name": "Dream Passport [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport.png",
     "region": "US",
     "description": "Forwarder installer for 05500000017c0000 and rom copier for roms/sdc/Dream Passport.chd"
   },
   "05500000017F0000": {
     "id": "05500000017F0000",
     "name": "Dream Preview Vol. 8 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%208%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%208.png",
     "region": "US",
     "description": "Forwarder installer for 05500000017e0000 and rom copier for roms/sdc/Dream Preview Vol. 8.chd"
   },
   "0550000001810000": {
     "id": "0550000001810000",
     "name": "Dreamcast Express Extra [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001800000 and rom copier for roms/sdc/Dreamcast Express Extra.chd"
   },
   "0550000001830000": {
     "id": "0550000001830000",
     "name": "Dreamcast Express Vol. 1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%201%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001820000 and rom copier for roms/sdc/Dreamcast Express Vol. 1.chd"
   },
   "0550000001850000": {
     "id": "0550000001850000",
     "name": "Dreamcast Express Vol. 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%202%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamcast%20Express%20Vol.%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001840000 and rom copier for roms/sdc/Dreamcast Express Vol. 2.chd"
   },
   "0550000001870000": {
     "id": "0550000001870000",
     "name": "Dreamcast Express Vol. 3 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%203%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dorimaga%20GD%20Vol.%203.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001860000 and rom copier for roms/sdc/Dreamcast Express Vol. 3.chd"
   },
   "0550000001890000": {
     "id": "0550000001890000",
     "name": "Dreamcast Express Vol. 4 Disc #1 Trial Disk [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%203%20-%20Urban%20Style%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%203%20-%20Urban%20Style.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001880000 and rom copier for roms/sdc/Dreamcast Express Vol. 4 Disc #1 Trial Disk.chd"
   },
   "05500000018B0000": {
     "id": "05500000018B0000",
     "name": "Dreamcast Express Vol. 4 Disc #2 Tokyo Game Show '99 Autumn - Special Disk [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Gundam%20Side%20Story%200079%20-%20Rise%20from%20the%20Ashes%20-%20Premium%20Disc%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Gundam%20Side%20Story%200079%20-%20Rise%20from%20the%20Ashes%20-%20Premium%20Disc.png",
     "region": "US",
     "description": "Forwarder installer for 05500000018a0000 and rom copier for roms/sdc/Dreamcast Express Vol. 4 Disc #2 Tokyo Game Show '99 Autumn - Special Disk.chd"
   },
   "05500000018D0000": {
     "id": "05500000018D0000",
     "name": "Dreamcast Express Vol. 5 Disc #1 Trial Disk [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%203%20-%20Urban%20Style%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%203%20-%20Urban%20Style.png",
     "region": "US",
     "description": "Forwarder installer for 05500000018c0000 and rom copier for roms/sdc/Dreamcast Express Vol. 5 Disc #1 Trial Disk.chd"
   },
   "05500000018F0000": {
     "id": "05500000018F0000",
     "name": "Dreamcast Express Vol. 5 Disc #2 Movie Disk [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%203%20-%20Urban%20Style%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%203%20-%20Urban%20Style.png",
     "region": "US",
     "description": "Forwarder installer for 05500000018e0000 and rom copier for roms/sdc/Dreamcast Express Vol. 5 Disc #2 Movie Disk.chd"
   },
   "0550000001910000": {
     "id": "0550000001910000",
     "name": "Dreamcast Express Vol. 6 Disc #1 Special Disk [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%203%20-%20Urban%20Style%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%203%20-%20Urban%20Style.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001900000 and rom copier for roms/sdc/Dreamcast Express Vol. 6 Disc #1 Special Disk.chd"
   },
   "0550000001930000": {
     "id": "0550000001930000",
     "name": "Dreamcast Express Vol. 6 Disc #2 Trial & Movie Disk [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%203%20-%20Urban%20Style%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%203%20-%20Urban%20Style.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001920000 and rom copier for roms/sdc/Dreamcast Express Vol. 6 Disc #2 Trial & Movie Disk.chd"
   },
   "0550000001950000": {
     "id": "0550000001950000",
     "name": "Dreamcast Express Vol. 7 Disc #1 Special Disk [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%203%20-%20Urban%20Style%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%203%20-%20Urban%20Style.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001940000 and rom copier for roms/sdc/Dreamcast Express Vol. 7 Disc #1 Special Disk.chd"
   },
   "0550000001970000": {
     "id": "0550000001970000",
     "name": "Dreamcast Express Vol. 7 Disc #2 Trial & Movie Disk [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%203%20-%20Urban%20Style%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%203%20-%20Urban%20Style.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001960000 and rom copier for roms/sdc/Dreamcast Express Vol. 7 Disc #2 Trial & Movie Disk.chd"
   },
   "0550000001990000": {
     "id": "0550000001990000",
     "name": "Dreamcast Middleware Conference Demo Disc Part.2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dragon%20Riders%20-%20Chronicles%20of%20Pern%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dragon%20Riders%20-%20Chronicles%20of%20Pern.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001980000 and rom copier for roms/sdc/Dreamcast Middleware Conference Demo Disc Part.2.chd"
   },
   "05500000019B0000": {
     "id": "05500000019B0000",
     "name": "Dreamcast Promotion Disk [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamkey%20Version%201.5%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamkey%20Version%201.5.png",
     "region": "US",
     "description": "Forwarder installer for 05500000019a0000 and rom copier for roms/sdc/Dreamcast Promotion Disk.chd"
   },
   "05500000019D0000": {
     "id": "05500000019D0000",
     "name": "Dreamkey 3.0 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamkey%203.0%20(Europe)%20(En,Fr,De,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamkey%203.0.png",
     "region": "US",
     "description": "Forwarder installer for 05500000019c0000 and rom copier for roms/sdc/Dreamkey 3.0.chd"
   },
   "05500000019F0000": {
     "id": "05500000019F0000",
     "name": "Dreamkey 3.1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamkey%203.1%20(Portugal).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamkey%203.1.png",
     "region": "US",
     "description": "Forwarder installer for 05500000019e0000 and rom copier for roms/sdc/Dreamkey 3.1.chd"
   },
   "0550000001A10000": {
     "id": "0550000001A10000",
     "name": "Dreamkey Version 1.5 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamkey%20Version%201.5%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamkey%20Version%201.5.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001a00000 and rom copier for roms/sdc/Dreamkey Version 1.5.chd"
   },
   "0550000001A30000": {
     "id": "0550000001A30000",
     "name": "Dreamkey Version 2.0 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamkey%20Version%202.0%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamkey%20Version%202.0.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001a20000 and rom copier for roms/sdc/Dreamkey Version 2.0.chd"
   },
   "0550000001A50000": {
     "id": "0550000001A50000",
     "name": "Dreamkey [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamkey%20(Australia).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamkey.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001a40000 and rom copier for roms/sdc/Dreamkey.chd"
   },
   "0550000001A70000": {
     "id": "0550000001A70000",
     "name": "Dreamon Collection 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%202%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001a60000 and rom copier for roms/sdc/Dreamon Collection 2.chd"
   },
   "0550000001A90000": {
     "id": "0550000001A90000",
     "name": "Dreamon Collection 3 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%202%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001a80000 and rom copier for roms/sdc/Dreamon Collection 3.chd"
   },
   "0550000001AB0000": {
     "id": "0550000001AB0000",
     "name": "Dreamon Collection 4 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%202%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001aa0000 and rom copier for roms/sdc/Dreamon Collection 4.chd"
   },
   "0550000001AD0000": {
     "id": "0550000001AD0000",
     "name": "Dreamon Volume 1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2010%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2010.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001ac0000 and rom copier for roms/sdc/Dreamon Volume 1.chd"
   },
   "0550000001AF0000": {
     "id": "0550000001AF0000",
     "name": "Dreamon Volume 10 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2010%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2010.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001ae0000 and rom copier for roms/sdc/Dreamon Volume 10.chd"
   },
   "0550000001B10000": {
     "id": "0550000001B10000",
     "name": "Dreamon Volume 11 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2010%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2010.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001b00000 and rom copier for roms/sdc/Dreamon Volume 11.chd"
   },
   "0550000001B30000": {
     "id": "0550000001B30000",
     "name": "Dreamon Volume 12 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2010%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2010.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001b20000 and rom copier for roms/sdc/Dreamon Volume 12.chd"
   },
   "0550000001B50000": {
     "id": "0550000001B50000",
     "name": "Dreamon Volume 13 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2010%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2010.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001b40000 and rom copier for roms/sdc/Dreamon Volume 13.chd"
   },
   "0550000001B70000": {
     "id": "0550000001B70000",
     "name": "Dreamon Volume 14 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2010%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2010.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001b60000 and rom copier for roms/sdc/Dreamon Volume 14.chd"
   },
   "0550000001B90000": {
     "id": "0550000001B90000",
     "name": "Dreamon Volume 15 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2010%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2010.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001b80000 and rom copier for roms/sdc/Dreamon Volume 15.chd"
   },
   "0550000001BB0000": {
     "id": "0550000001BB0000",
     "name": "Dreamon Volume 16 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2010%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2010.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001ba0000 and rom copier for roms/sdc/Dreamon Volume 16.chd"
   },
   "0550000001BD0000": {
     "id": "0550000001BD0000",
     "name": "Dreamon Volume 17 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2010%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2010.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001bc0000 and rom copier for roms/sdc/Dreamon Volume 17.chd"
   },
   "0550000001BF0000": {
     "id": "0550000001BF0000",
     "name": "Dreamon Volume 18 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2010%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2010.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001be0000 and rom copier for roms/sdc/Dreamon Volume 18.chd"
   },
   "0550000001C10000": {
     "id": "0550000001C10000",
     "name": "Dreamon Volume 19 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2010%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2010.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001c00000 and rom copier for roms/sdc/Dreamon Volume 19.chd"
   },
   "0550000001C30000": {
     "id": "0550000001C30000",
     "name": "Dreamon Volume 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%202%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001c20000 and rom copier for roms/sdc/Dreamon Volume 2.chd"
   },
   "0550000001C50000": {
     "id": "0550000001C50000",
     "name": "Dreamon Volume 20 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2010%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2010.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001c40000 and rom copier for roms/sdc/Dreamon Volume 20.chd"
   },
   "0550000001C70000": {
     "id": "0550000001C70000",
     "name": "Dreamon Volume 21 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2021%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2021.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001c60000 and rom copier for roms/sdc/Dreamon Volume 21.chd"
   },
   "0550000001C90000": {
     "id": "0550000001C90000",
     "name": "Dreamon Volume 22 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%202%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001c80000 and rom copier for roms/sdc/Dreamon Volume 22.chd"
   },
   "0550000001CB0000": {
     "id": "0550000001CB0000",
     "name": "Dreamon Volume 3 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%202%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001ca0000 and rom copier for roms/sdc/Dreamon Volume 3.chd"
   },
   "0550000001CD0000": {
     "id": "0550000001CD0000",
     "name": "Dreamon Volume 4 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%202%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001cc0000 and rom copier for roms/sdc/Dreamon Volume 4.chd"
   },
   "0550000001CF0000": {
     "id": "0550000001CF0000",
     "name": "Dreamon Volume 5 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%202%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001ce0000 and rom copier for roms/sdc/Dreamon Volume 5.chd"
   },
   "0550000001D10000": {
     "id": "0550000001D10000",
     "name": "Dreamon Volume 6 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%202%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001d00000 and rom copier for roms/sdc/Dreamon Volume 6.chd"
   },
   "0550000001D30000": {
     "id": "0550000001D30000",
     "name": "Dreamon Volume 7 & 8 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2010%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%2010.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001d20000 and rom copier for roms/sdc/Dreamon Volume 7 & 8.chd"
   },
   "0550000001D50000": {
     "id": "0550000001D50000",
     "name": "Dreamon Volume 7 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%202%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001d40000 and rom copier for roms/sdc/Dreamon Volume 7.chd"
   },
   "0550000001D70000": {
     "id": "0550000001D70000",
     "name": "Dreamon Volume 8 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%202%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001d60000 and rom copier for roms/sdc/Dreamon Volume 8.chd"
   },
   "0550000001D90000": {
     "id": "0550000001D90000",
     "name": "Dreamon Volume 9 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%202%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamon%20Volume%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001d80000 and rom copier for roms/sdc/Dreamon Volume 9.chd"
   },
   "0550000001DB0000": {
     "id": "0550000001DB0000",
     "name": "Dreamstud!o [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamkey%20(Australia).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dreamkey.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001da0000 and rom copier for roms/sdc/Dreamstud!o.chd"
   },
   "0550000001DD0000": {
     "id": "0550000001DD0000",
     "name": "Ducati World - Racing Challenge [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ducati%20World%20-%20Racing%20Challenge%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ducati%20World%20-%20Racing%20Challenge.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001dc0000 and rom copier for roms/sdc/Ducati World - Racing Challenge.chd"
   },
   "0550000001DF0000": {
     "id": "0550000001DF0000",
     "name": "Ducati World [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ducati%20World%20(Europe)%20(En,Fr,De,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ducati%20World.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001de0000 and rom copier for roms/sdc/Ducati World.chd"
   },
   "0550000001E10000": {
     "id": "0550000001E10000",
     "name": "Dynamite Cop! [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dynamite%20Cop!%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dynamite%20Cop!.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001e00000 and rom copier for roms/sdc/Dynamite Cop!.chd"
   },
   "0550000001E30000": {
     "id": "0550000001E30000",
     "name": "Dynamite Deka 2 Demo #1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dynamite%20Deka%202%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dynamite%20Deka%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001e20000 and rom copier for roms/sdc/Dynamite Deka 2 Demo #1.chd"
   },
   "0550000001E50000": {
     "id": "0550000001E50000",
     "name": "Dynamite Deka 2 Demo #2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dynamite%20Deka%202%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dynamite%20Deka%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001e40000 and rom copier for roms/sdc/Dynamite Deka 2 Demo #2.chd"
   },
   "0550000001E70000": {
     "id": "0550000001E70000",
     "name": "Dynamite Deka 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dynamite%20Deka%202%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dynamite%20Deka%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001e60000 and rom copier for roms/sdc/Dynamite Deka 2.chd"
   },
   "0550000001E90000": {
     "id": "0550000001E90000",
     "name": "ECW Anarchy Rulz [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/ECW%20Anarchy%20Rulz%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/ECW%20Anarchy%20Rulz.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001e80000 and rom copier for roms/sdc/ECW Anarchy Rulz.chd"
   },
   "0550000001EB0000": {
     "id": "0550000001EB0000",
     "name": "ECW Hardcore Revolution [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/ECW%20Hardcore%20Revolution%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/ECW%20Hardcore%20Revolution.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001ea0000 and rom copier for roms/sdc/ECW Hardcore Revolution.chd"
   },
   "0550000001ED0000": {
     "id": "0550000001ED0000",
     "name": "Eisei Meijin III - Game Creator Yoshimura Nobuhiro no Zunou [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eisei%20Meijin%20III%20-%20Game%20Creator%20Yoshimura%20Nobuhiro%20no%20Zunou%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eisei%20Meijin%20III%20-%20Game%20Creator%20Yoshimura%20Nobuhiro%20no%20Zunou.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001ec0000 and rom copier for roms/sdc/Eisei Meijin III - Game Creator Yoshimura Nobuhiro no Zunou.chd"
   },
   "0550000001EF0000": {
     "id": "0550000001EF0000",
     "name": "Eldorado Gate Dai-1-kan [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eldorado%20Gate%20Dai-1-kan%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eldorado%20Gate%20Dai-1-kan.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001ee0000 and rom copier for roms/sdc/Eldorado Gate Dai-1-kan.chd"
   },
   "0550000001F10000": {
     "id": "0550000001F10000",
     "name": "Eldorado Gate Dai-2-kan [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eldorado%20Gate%20Dai-2-kan%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eldorado%20Gate%20Dai-2-kan.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001f00000 and rom copier for roms/sdc/Eldorado Gate Dai-2-kan.chd"
   },
   "0550000001F30000": {
     "id": "0550000001F30000",
     "name": "Eldorado Gate Dai-3-kan [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eldorado%20Gate%20Dai-3-kan%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eldorado%20Gate%20Dai-3-kan.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001f20000 and rom copier for roms/sdc/Eldorado Gate Dai-3-kan.chd"
   },
   "0550000001F50000": {
     "id": "0550000001F50000",
     "name": "Eldorado Gate Dai-4-kan [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eldorado%20Gate%20Dai-4-kan%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eldorado%20Gate%20Dai-4-kan.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001f40000 and rom copier for roms/sdc/Eldorado Gate Dai-4-kan.chd"
   },
   "0550000001F70000": {
     "id": "0550000001F70000",
     "name": "Eldorado Gate Dai-5-kan [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eldorado%20Gate%20Dai-5-kan%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eldorado%20Gate%20Dai-5-kan.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001f60000 and rom copier for roms/sdc/Eldorado Gate Dai-5-kan.chd"
   },
   "0550000001F90000": {
     "id": "0550000001F90000",
     "name": "Eldorado Gate Dai-6-kan [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eldorado%20Gate%20Dai-6-kan%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eldorado%20Gate%20Dai-6-kan.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001f80000 and rom copier for roms/sdc/Eldorado Gate Dai-6-kan.chd"
   },
   "0550000001FB0000": {
     "id": "0550000001FB0000",
     "name": "Eldorado Gate Dai-7-kan [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eldorado%20Gate%20Dai-7-kan%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eldorado%20Gate%20Dai-7-kan.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001fa0000 and rom copier for roms/sdc/Eldorado Gate Dai-7-kan.chd"
   },
   "0550000001FD0000": {
     "id": "0550000001FD0000",
     "name": "Elemental Gimmick Gear [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Elemental%20Gimmick%20Gear%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Elemental%20Gimmick%20Gear.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001fc0000 and rom copier for roms/sdc/Elemental Gimmick Gear.chd"
   },
   "0550000001FF0000": {
     "id": "0550000001FF0000",
     "name": "Elysion - Eien no Sanctuary [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Elysion%20-%20Eien%20no%20Sanctuary%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Elysion%20-%20Eien%20no%20Sanctuary.png",
     "region": "US",
     "description": "Forwarder installer for 0550000001fe0000 and rom copier for roms/sdc/Elysion - Eien no Sanctuary.chd"
   },
   "0550000002010000": {
     "id": "0550000002010000",
     "name": "Erde - Nezu no Ki no Shita de [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Erde%20-%20Nezu%20no%20Ki%20no%20Shita%20de%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Erde%20-%20Nezu%20no%20Ki%20no%20Shita%20de.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002000000 and rom copier for roms/sdc/Erde - Nezu no Ki no Shita de.chd"
   },
   "0550000002030000": {
     "id": "0550000002030000",
     "name": "Es Disc #1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tetris%204D%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tetris%204D.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002020000 and rom copier for roms/sdc/Es Disc #1.chd"
   },
   "0550000002050000": {
     "id": "0550000002050000",
     "name": "Es Disc #2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Get%20Bass%202%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Get%20Bass%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002040000 and rom copier for roms/sdc/Es Disc #2.chd"
   },
   "0550000002070000": {
     "id": "0550000002070000",
     "name": "Es Disc #3 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Macross%20M3%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Macross%20M3.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002060000 and rom copier for roms/sdc/Es Disc #3.chd"
   },
   "0550000002090000": {
     "id": "0550000002090000",
     "name": "Espion-Age-nts [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Espion-Age-nts%20(Japan)%20(Tentou-you%20Demonstration%20Movie).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Espion-Age-nts.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002080000 and rom copier for roms/sdc/Espion-Age-nts.chd"
   },
   "05500000020B0000": {
     "id": "05500000020B0000",
     "name": "ESPN International Track & Field [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/ESPN%20International%20Track%20_%20Field%20(Europe)%20(En,Fr,De).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/ESPN%20International%20Track%20%26%20Field.png",
     "region": "US",
     "description": "Forwarder installer for 05500000020a0000 and rom copier for roms/sdc/ESPN International Track & Field.chd"
   },
   "05500000020D0000": {
     "id": "05500000020D0000",
     "name": "ESPN NBA 2Night [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/ESPN%20NBA%202Night%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/ESPN%20NBA%202Night.png",
     "region": "US",
     "description": "Forwarder installer for 05500000020c0000 and rom copier for roms/sdc/ESPN NBA 2Night.chd"
   },
   "05500000020F0000": {
     "id": "05500000020F0000",
     "name": "Eternal Arcadia - Kuuzokuban [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eternal%20Arcadia%20-%20Kuuzokuban%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eternal%20Arcadia%20-%20Kuuzokuban.png",
     "region": "US",
     "description": "Forwarder installer for 05500000020e0000 and rom copier for roms/sdc/Eternal Arcadia - Kuuzokuban.chd"
   },
   "0550000002110000": {
     "id": "0550000002110000",
     "name": "Eternal Arcadia Disc #1 @barai [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eternal%20Arcadia%20-%20Kuuzokuban%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eternal%20Arcadia%20Disc%20%231%20%40barai.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002100000 and rom copier for roms/sdc/Eternal Arcadia Disc #1 @barai.chd"
   },
   "0550000002130000": {
     "id": "0550000002130000",
     "name": "Eternal Arcadia Disc #1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eternal%20Arcadia%20(Japan)%20(Disc%201)%20(@barai).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eternal%20Arcadia%20Disc%20%231.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002120000 and rom copier for roms/sdc/Eternal Arcadia Disc #1.chd"
   },
   "0550000002150000": {
     "id": "0550000002150000",
     "name": "Eternal Arcadia Disc #2 @barai [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eternal%20Arcadia%20-%20Kuuzokuban%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eternal%20Arcadia%20Disc%20%232%20%40barai.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002140000 and rom copier for roms/sdc/Eternal Arcadia Disc #2 @barai.chd"
   },
   "0550000002170000": {
     "id": "0550000002170000",
     "name": "Eternal Arcadia Disc #2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eternal%20Arcadia%20(Japan)%20(Disc%201)%20(@barai).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eternal%20Arcadia%20Disc%20%232.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002160000 and rom copier for roms/sdc/Eternal Arcadia Disc #2.chd"
   },
   "0550000002190000": {
     "id": "0550000002190000",
     "name": "European Super League [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/European%20Super%20League%20(Europe)%20(En,Fr,De,Es,It,Pt).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/European%20Super%20League.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002180000 and rom copier for roms/sdc/European Super League.chd"
   },
   "05500000021B0000": {
     "id": "05500000021B0000",
     "name": "Eve Zero Kanzenban - Ark of the Matter Disc #2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eve%20Zero%20Kanzenban%20-%20Ark%20of%20the%20Matter%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eve%20Zero%20Kanzenban%20-%20Ark%20of%20the%20Matter%20Disc%20%232.png",
     "region": "US",
     "description": "Forwarder installer for 05500000021a0000 and rom copier for roms/sdc/Eve Zero Kanzenban - Ark of the Matter Disc #2.chd"
   },
   "05500000021D0000": {
     "id": "05500000021D0000",
     "name": "Eve Zero Kanzenban - Ark of the Matter Disk #1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eve%20Zero%20Kanzenban%20-%20Ark%20of%20the%20Matter%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Eve%20Zero%20Kanzenban%20-%20Ark%20of%20the%20Matter%20Disk%20%231.png",
     "region": "US",
     "description": "Forwarder installer for 05500000021c0000 and rom copier for roms/sdc/Eve Zero Kanzenban - Ark of the Matter Disk #1.chd"
   },
   "05500000021F0000": {
     "id": "05500000021F0000",
     "name": "Ever 17 - The Out of Infinity [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ever%2017%20-%20The%20Out%20of%20Infinity%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ever%2017%20-%20The%20Out%20of%20Infinity.png",
     "region": "US",
     "description": "Forwarder installer for 05500000021e0000 and rom copier for roms/sdc/Ever 17 - The Out of Infinity.chd"
   },
   "0550000002210000": {
     "id": "0550000002210000",
     "name": "Evil Dead - Hail to the King [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Evil%20Dead%20-%20Hail%20to%20the%20King%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Evil%20Dead%20-%20Hail%20to%20the%20King.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002200000 and rom copier for roms/sdc/Evil Dead - Hail to the King.chd"
   },
   "0550000002230000": {
     "id": "0550000002230000",
     "name": "Evil Twin - Cyprien's Chronicles [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Evil%20Twin%20-%20Cyprien's%20Chronicles%20(Europe)%20(En,Fr).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Evil%20Twin%20-%20Cyprien's%20Chronicles.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002220000 and rom copier for roms/sdc/Evil Twin - Cyprien's Chronicles.chd"
   },
   "0550000002250000": {
     "id": "0550000002250000",
     "name": "Evolution - The World of Sacred Device [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Evolution%20-%20The%20World%20of%20Sacred%20Device%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Evolution%20-%20The%20World%20of%20Sacred%20Device.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002240000 and rom copier for roms/sdc/Evolution - The World of Sacred Device.chd"
   },
   "0550000002270000": {
     "id": "0550000002270000",
     "name": "Evolution 2 - Far Off Promise [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Evolution%202%20-%20Far%20Off%20Promise%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Evolution%202%20-%20Far%20Off%20Promise.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002260000 and rom copier for roms/sdc/Evolution 2 - Far Off Promise.chd"
   },
   "0550000002290000": {
     "id": "0550000002290000",
     "name": "Exhibition of Speed [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Exhibition%20of%20Speed%20(Europe)%20(En,Fr,De,Es,It,Nl).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Exhibition%20of%20Speed.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002280000 and rom copier for roms/sdc/Exhibition of Speed.chd"
   },
   "05500000022B0000": {
     "id": "05500000022B0000",
     "name": "Exodus Guilty Neos [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Exodus%20Guilty%20Neos%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Exodus%20Guilty%20Neos.png",
     "region": "US",
     "description": "Forwarder installer for 05500000022a0000 and rom copier for roms/sdc/Exodus Guilty Neos.chd"
   },
   "05500000022D0000": {
     "id": "05500000022D0000",
     "name": "Expendable [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Expendable%20(USA)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Expendable.png",
     "region": "US",
     "description": "Forwarder installer for 05500000022c0000 and rom copier for roms/sdc/Expendable.chd"
   },
   "05500000022F0000": {
     "id": "05500000022F0000",
     "name": "F1 Racing Championship [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/F1%20Racing%20Championship%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/F1%20Racing%20Championship.png",
     "region": "US",
     "description": "Forwarder installer for 05500000022e0000 and rom copier for roms/sdc/F1 Racing Championship.chd"
   },
   "0550000002310000": {
     "id": "0550000002310000",
     "name": "F1 World Grand Prix for Dreamcast [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/F1%20World%20Grand%20Prix%20for%20Dreamcast%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/F1%20World%20Grand%20Prix%20for%20Dreamcast.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002300000 and rom copier for roms/sdc/F1 World Grand Prix for Dreamcast.chd"
   },
   "0550000002330000": {
     "id": "0550000002330000",
     "name": "F1 World Grand Prix II for Dreamcast [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/F1%20World%20Grand%20Prix%20II%20for%20Dreamcast%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/F1%20World%20Grand%20Prix%20II%20for%20Dreamcast.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002320000 and rom copier for roms/sdc/F1 World Grand Prix II for Dreamcast.chd"
   },
   "0550000002350000": {
     "id": "0550000002350000",
     "name": "F1 World Grand Prix [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/F1%20World%20Grand%20Prix%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/F1%20World%20Grand%20Prix.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002340000 and rom copier for roms/sdc/F1 World Grand Prix.chd"
   },
   "0550000002370000": {
     "id": "0550000002370000",
     "name": "F355 Challenge - Passione Rossa [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/F355%20Challenge%20-%20Passione%20Rossa%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/F355%20Challenge%20-%20Passione%20Rossa.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002360000 and rom copier for roms/sdc/F355 Challenge - Passione Rossa.chd"
   },
   "0550000002390000": {
     "id": "0550000002390000",
     "name": "Fatal Fury - Mark of the Wolves [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Fatal%20Fury%20-%20Mark%20of%20the%20Wolves%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Fatal%20Fury%20-%20Mark%20of%20the%20Wolves.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002380000 and rom copier for roms/sdc/Fatal Fury - Mark of the Wolves.chd"
   },
   "05500000023B0000": {
     "id": "05500000023B0000",
     "name": "Fighting Force 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Fighting%20Force%202%20(Europe)%20(En,Fr).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Fighting%20Force%202.png",
     "region": "US",
     "description": "Forwarder installer for 05500000023a0000 and rom copier for roms/sdc/Fighting Force 2.chd"
   },
   "05500000023D0000": {
     "id": "05500000023D0000",
     "name": "Fighting Vipers 2 Beta [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Fighting%20Vipers%202%20(Europe)%20(En,Ja,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Fighting%20Vipers%202%20Beta.png",
     "region": "US",
     "description": "Forwarder installer for 05500000023c0000 and rom copier for roms/sdc/Fighting Vipers 2 Beta.chd"
   },
   "05500000023F0000": {
     "id": "05500000023F0000",
     "name": "Fire Pro Wrestling D [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Fire%20Pro%20Wrestling%20D%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Fire%20Pro%20Wrestling%20D.png",
     "region": "US",
     "description": "Forwarder installer for 05500000023e0000 and rom copier for roms/sdc/Fire Pro Wrestling D.chd"
   },
   "0550000002410000": {
     "id": "0550000002410000",
     "name": "First Kiss Story Disc #1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Fighting%20Force%202%20(Europe)%20(En,Fr).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Fighting%20Force%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002400000 and rom copier for roms/sdc/First Kiss Story Disc #1.chd"
   },
   "0550000002430000": {
     "id": "0550000002430000",
     "name": "First Kiss Story Disc #2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Fighting%20Force%202%20(Europe)%20(En,Fr).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Fighting%20Force%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002420000 and rom copier for roms/sdc/First Kiss Story Disc #2.chd"
   },
   "0550000002450000": {
     "id": "0550000002450000",
     "name": "First Kiss Story II - Anata ga Iru kara Disc #1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Frame%20Gride%20-%20Test%20Operation%20Disc%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Frame%20Gride%20-%20Test%20Operation%20Disc.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002440000 and rom copier for roms/sdc/First Kiss Story II - Anata ga Iru kara Disc #1.chd"
   },
   "0550000002470000": {
     "id": "0550000002470000",
     "name": "First Kiss Story II - Anata ga Iru kara Disc #2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Frame%20Gride%20-%20Test%20Operation%20Disc%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Frame%20Gride%20-%20Test%20Operation%20Disc.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002460000 and rom copier for roms/sdc/First Kiss Story II - Anata ga Iru kara Disc #2.chd"
   },
   "0550000002490000": {
     "id": "0550000002490000",
     "name": "Fish Eyes + Wild [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Fish%20Eyes%20+%20Wild%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Fish%20Eyes%20+%20Wild.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002480000 and rom copier for roms/sdc/Fish Eyes + Wild.chd"
   },
   "05500000024B0000": {
     "id": "05500000024B0000",
     "name": "Flag to Flag [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Flag%20to%20Flag%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Flag%20to%20Flag.png",
     "region": "US",
     "description": "Forwarder installer for 05500000024a0000 and rom copier for roms/sdc/Flag to Flag.chd"
   },
   "05500000024D0000": {
     "id": "05500000024D0000",
     "name": "Floigan Bros. - Episode 1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Floigan%20Bros.%20-%20Episode%201%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Floigan%20Bros.%20-%20Episode%201.png",
     "region": "US",
     "description": "Forwarder installer for 05500000024c0000 and rom copier for roms/sdc/Floigan Bros. - Episode 1.chd"
   },
   "05500000024F0000": {
     "id": "05500000024F0000",
     "name": "For Symphony - With All One's Heart [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/For%20Symphony%20-%20With%20All%20One's%20Heart%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/For%20Symphony%20-%20With%20All%20One's%20Heart.png",
     "region": "US",
     "description": "Forwarder installer for 05500000024e0000 and rom copier for roms/sdc/For Symphony - With All One's Heart.chd"
   },
   "0550000002510000": {
     "id": "0550000002510000",
     "name": "Fragrance Tale [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Fragrance%20Tale%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Fragrance%20Tale.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002500000 and rom copier for roms/sdc/Fragrance Tale.chd"
   },
   "0550000002530000": {
     "id": "0550000002530000",
     "name": "Frame Gride - Test Operation Disc [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Frame%20Gride%20-%20Test%20Operation%20Disc%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Frame%20Gride%20-%20Test%20Operation%20Disc.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002520000 and rom copier for roms/sdc/Frame Gride - Test Operation Disc.chd"
   },
   "0550000002550000": {
     "id": "0550000002550000",
     "name": "Frame Gride [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Frame%20Gride%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Frame%20Gride.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002540000 and rom copier for roms/sdc/Frame Gride.chd"
   },
   "0550000002570000": {
     "id": "0550000002570000",
     "name": "Freestyle Scooter [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Freestyle%20Scooter%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Freestyle%20Scooter.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002560000 and rom copier for roms/sdc/Freestyle Scooter.chd"
   },
   "0550000002590000": {
     "id": "0550000002590000",
     "name": "Frogger 2 - Swampy's Revenge [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Frogger%202%20-%20Swampy's%20Revenge%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Frogger%202%20-%20Swampy's%20Revenge.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002580000 and rom copier for roms/sdc/Frogger 2 - Swampy's Revenge.chd"
   },
   "05500000025B0000": {
     "id": "05500000025B0000",
     "name": "Fur Fighters + Dead or Alive 2 Demo [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dead%20or%20Alive%202%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dead%20or%20Alive%202.png",
     "region": "US",
     "description": "Forwarder installer for 05500000025a0000 and rom copier for roms/sdc/Fur Fighters + Dead or Alive 2 Demo.chd"
   },
   "05500000025D0000": {
     "id": "05500000025D0000",
     "name": "Fur Fighters Demo [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Fur%20Fighters%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Fur%20Fighters.png",
     "region": "US",
     "description": "Forwarder installer for 05500000025c0000 and rom copier for roms/sdc/Fur Fighters Demo.chd"
   },
   "05500000025F0000": {
     "id": "05500000025F0000",
     "name": "Fur Fighters [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Fur%20Fighters%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Fur%20Fighters.png",
     "region": "US",
     "description": "Forwarder installer for 05500000025e0000 and rom copier for roms/sdc/Fur Fighters.chd"
   },
   "0550000002610000": {
     "id": "0550000002610000",
     "name": "Fushigi no Dungeon - Fuurai no Shiren Gaiden - Onna Kenshi Asuka Kenzan! [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Fushigi%20no%20Dungeon%20-%20Fuurai%20no%20Shiren%20Gaiden%20-%20Onna%20Kenshi%20Asuka%20Kenzan!%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Fushigi%20no%20Dungeon%20-%20Fuurai%20no%20Shiren%20Gaiden%20-%20Onna%20Kenshi%20Asuka%20Kenzan!.png",
     "region": "US",
     "description": "Forwarder installer for 0550000002600000 and rom copier for roms/sdc/Fushigi no Dungeon - Fuurai no Shiren Gaiden - Onna Kenshi Asuka Kenzan!.chd"
   },
   "0550100000010000": {
     "id": "0550100000010000",
     "name": "GaiaMaster - Kessen! Seiki-ou Densetsu [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/GaiaMaster%20-%20Kessen!%20Seiki-ou%20Densetsu%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/GaiaMaster%20-%20Kessen!%20Seiki-ou%20Densetsu.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000000000 and rom copier for roms/sdc/GaiaMaster - Kessen! Seiki-ou Densetsu.chd"
   },
   "0550100000030000": {
     "id": "0550100000030000",
     "name": "Gakkyuu-ou Yamazaki - Yamazaki Oukoku Daifunsou! [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Gakkyuu-ou%20Yamazaki%20-%20Yamazaki%20Oukoku%20Daifunsou!%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Gakkyuu-ou%20Yamazaki%20-%20Yamazaki%20Oukoku%20Daifunsou!.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000020000 and rom copier for roms/sdc/Gakkyuu-ou Yamazaki - Yamazaki Oukoku Daifunsou!.chd"
   },
   "0550100000050000": {
     "id": "0550100000050000",
     "name": "Ganbare! Nippon! Olympic 2000 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ganbare!%20Nippon!%20Olympic%202000%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ganbare!%20Nippon!%20Olympic%202000.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000040000 and rom copier for roms/sdc/Ganbare! Nippon! Olympic 2000.chd"
   },
   "0550100000070000": {
     "id": "0550100000070000",
     "name": "Garou - Mark of the Wolves [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Garou%20-%20Mark%20of%20the%20Wolves%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Garou%20-%20Mark%20of%20the%20Wolves.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000060000 and rom copier for roms/sdc/Garou - Mark of the Wolves.chd"
   },
   "0550100000090000": {
     "id": "0550100000090000",
     "name": "Gauntlet Legends [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Gauntlet%20Legends%20(Europe)%20(En,Fr,De).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Gauntlet%20Legends.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000080000 and rom copier for roms/sdc/Gauntlet Legends.chd"
   },
   "05501000000B0000": {
     "id": "05501000000B0000",
     "name": "Generator Vol. 1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Generator%20Vol.%201%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Generator%20Vol.%201.png",
     "region": "US",
     "description": "Forwarder installer for 05501000000a0000 and rom copier for roms/sdc/Generator Vol. 1.chd"
   },
   "05501000000D0000": {
     "id": "05501000000D0000",
     "name": "Generator Vol. 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Generator%20Vol.%202%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Generator%20Vol.%202.png",
     "region": "US",
     "description": "Forwarder installer for 05501000000c0000 and rom copier for roms/sdc/Generator Vol. 2.chd"
   },
   "05501000000F0000": {
     "id": "05501000000F0000",
     "name": "Get Bass 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Get%20Bass%202%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Get%20Bass%202.png",
     "region": "US",
     "description": "Forwarder installer for 05501000000e0000 and rom copier for roms/sdc/Get Bass 2.chd"
   },
   "0550100000110000": {
     "id": "0550100000110000",
     "name": "Get Bass [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Get%20Bass%20(Japan)%20(Taikenban).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Get%20Bass.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000100000 and rom copier for roms/sdc/Get Bass.chd"
   },
   "0550100000130000": {
     "id": "0550100000130000",
     "name": "Get!! Colonies [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Get!!%20Colonies%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Get!!%20Colonies.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000120000 and rom copier for roms/sdc/Get!! Colonies.chd"
   },
   "0550100000150000": {
     "id": "0550100000150000",
     "name": "Giant Gram - Zen Nihon Pro Wres 2 in Nihon Budoukan [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Giant%20Gram%20-%20Zen%20Nihon%20Pro%20Wres%202%20in%20Nihon%20Budoukan%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Giant%20Gram%20-%20Zen%20Nihon%20Pro%20Wres%202%20in%20Nihon%20Budoukan.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000140000 and rom copier for roms/sdc/Giant Gram - Zen Nihon Pro Wres 2 in Nihon Budoukan.chd"
   },
   "0550100000170000": {
     "id": "0550100000170000",
     "name": "Giant Gram 2000 - Zen Nihon Pro Wres 3 Eikou no Yuusha-tachi [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Giant%20Gram%202000%20-%20Zen%20Nihon%20Pro%20Wres%203%20Eikou%20no%20Yuusha-tachi%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Giant%20Gram%202000%20-%20Zen%20Nihon%20Pro%20Wres%203%20Eikou%20no%20Yuusha-tachi.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000160000 and rom copier for roms/sdc/Giant Gram 2000 - Zen Nihon Pro Wres 3 Eikou no Yuusha-tachi.chd"
   },
   "0550100000190000": {
     "id": "0550100000190000",
     "name": "GigaWing 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/GigaWing%202%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/GigaWing%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000180000 and rom copier for roms/sdc/GigaWing 2.chd"
   },
   "05501000001B0000": {
     "id": "05501000001B0000",
     "name": "GigaWing [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/GigaWing%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/GigaWing.png",
     "region": "US",
     "description": "Forwarder installer for 05501000001a0000 and rom copier for roms/sdc/GigaWing.chd"
   },
   "05501000001D0000": {
     "id": "05501000001D0000",
     "name": "GK - Giant Killers [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/GK%20-%20Giant%20Killers%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/GK%20-%20Giant%20Killers.png",
     "region": "US",
     "description": "Forwarder installer for 05501000001c0000 and rom copier for roms/sdc/GK - Giant Killers.chd"
   },
   "05501000001F0000": {
     "id": "05501000001F0000",
     "name": "Godzilla Generations - Maximum Impact [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Godzilla%20Generations%20-%20Maximum%20Impact%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Godzilla%20Generations%20-%20Maximum%20Impact.png",
     "region": "US",
     "description": "Forwarder installer for 05501000001e0000 and rom copier for roms/sdc/Godzilla Generations - Maximum Impact.chd"
   },
   "0550100000210000": {
     "id": "0550100000210000",
     "name": "Godzilla Generations [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Godzilla%20Generations%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Godzilla%20Generations.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000200000 and rom copier for roms/sdc/Godzilla Generations.chd"
   },
   "0550100000230000": {
     "id": "0550100000230000",
     "name": "Golem no Maigo [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Golem%20no%20Maigo%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Golem%20no%20Maigo.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000220000 and rom copier for roms/sdc/Golem no Maigo.chd"
   },
   "0550100000250000": {
     "id": "0550100000250000",
     "name": "Golf Shiyou yo - Course Data-shuu - Adventure-hen [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Golf%20Shiyou%20yo%20-%20Course%20Data-shuu%20-%20Adventure-hen%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Golf%20Shiyou%20yo%20-%20Course%20Data-shuu%20-%20Adventure-hen.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000240000 and rom copier for roms/sdc/Golf Shiyou yo - Course Data-shuu - Adventure-hen.chd"
   },
   "0550100000270000": {
     "id": "0550100000270000",
     "name": "Golf Shiyou yo 2 - Aratanaru Chousen [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Golf%20Shiyou%20yo%202%20-%20Aratanaru%20Chousen%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Golf%20Shiyou%20yo%202%20-%20Aratanaru%20Chousen.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000260000 and rom copier for roms/sdc/Golf Shiyou yo 2 - Aratanaru Chousen.chd"
   },
   "0550100000290000": {
     "id": "0550100000290000",
     "name": "Golf Shiyou yo [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Golf%20Shiyou%20yo%20(Japan)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Golf%20Shiyou%20yo.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000280000 and rom copier for roms/sdc/Golf Shiyou yo.chd"
   },
   "05501000002B0000": {
     "id": "05501000002B0000",
     "name": "Grand Theft Auto 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Grand%20Theft%20Auto%202%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Grand%20Theft%20Auto%202.png",
     "region": "US",
     "description": "Forwarder installer for 05501000002a0000 and rom copier for roms/sdc/Grand Theft Auto 2.chd"
   },
   "05501000002D0000": {
     "id": "05501000002D0000",
     "name": "Grandia II [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Grandia%20II%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Grandia%20II.png",
     "region": "US",
     "description": "Forwarder installer for 05501000002c0000 and rom copier for roms/sdc/Grandia II.chd"
   },
   "05501000002F0000": {
     "id": "05501000002F0000",
     "name": "Grauen no Torikago - Kapitel 1 - Keiyaku [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Grauen%20no%20Torikago%20-%20Kapitel%201%20-%20Keiyaku%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Grauen%20no%20Torikago%20-%20Kapitel%201%20-%20Keiyaku.png",
     "region": "US",
     "description": "Forwarder installer for 05501000002e0000 and rom copier for roms/sdc/Grauen no Torikago - Kapitel 1 - Keiyaku.chd"
   },
   "0550100000310000": {
     "id": "0550100000310000",
     "name": "Grauen no Torikago - Kapitel 2 - Torikago [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Grauen%20no%20Torikago%20-%20Kapitel%202%20-%20Torikago%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Grauen%20no%20Torikago%20-%20Kapitel%202%20-%20Torikago.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000300000 and rom copier for roms/sdc/Grauen no Torikago - Kapitel 2 - Torikago.chd"
   },
   "0550100000330000": {
     "id": "0550100000330000",
     "name": "Grauen no Torikago - Kapitel 3 - Kansei [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Grauen%20no%20Torikago%20-%20Kapitel%203%20-%20Kansei%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Grauen%20no%20Torikago%20-%20Kapitel%203%20-%20Kansei.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000320000 and rom copier for roms/sdc/Grauen no Torikago - Kapitel 3 - Kansei.chd"
   },
   "0550100000350000": {
     "id": "0550100000350000",
     "name": "Grauen no Torikago - Kapitel 4 - Kaikou [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Grauen%20no%20Torikago%20-%20Kapitel%204%20-%20Kaikou%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Grauen%20no%20Torikago%20-%20Kapitel%204%20-%20Kaikou.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000340000 and rom copier for roms/sdc/Grauen no Torikago - Kapitel 4 - Kaikou.chd"
   },
   "0550100000370000": {
     "id": "0550100000370000",
     "name": "Grauen no Torikago - Kapitel 5 - Shokuzai [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Grauen%20no%20Torikago%20-%20Kapitel%205%20-%20Shokuzai%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Grauen%20no%20Torikago%20-%20Kapitel%205%20-%20Shokuzai.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000360000 and rom copier for roms/sdc/Grauen no Torikago - Kapitel 5 - Shokuzai.chd"
   },
   "0550100000390000": {
     "id": "0550100000390000",
     "name": "Grauen no Torikago - Kapitel 6 - Senritsu [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Grauen%20no%20Torikago%20-%20Kapitel%201%20-%20Keiyaku%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Grauen%20no%20Torikago%20-%20Kapitel%201%20-%20Keiyaku.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000380000 and rom copier for roms/sdc/Grauen no Torikago - Kapitel 6 - Senritsu.chd"
   },
   "05501000003B0000": {
     "id": "05501000003B0000",
     "name": "Guilty Gear X Demo [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Guilty%20Gear%20X%20(Japan)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Guilty%20Gear%20X.png",
     "region": "US",
     "description": "Forwarder installer for 05501000003a0000 and rom copier for roms/sdc/Guilty Gear X Demo.chd"
   },
   "05501000003D0000": {
     "id": "05501000003D0000",
     "name": "Guilty Gear X [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Guilty%20Gear%20X%20(Japan)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Guilty%20Gear%20X.png",
     "region": "US",
     "description": "Forwarder installer for 05501000003c0000 and rom copier for roms/sdc/Guilty Gear X.chd"
   },
   "05501000003F0000": {
     "id": "05501000003F0000",
     "name": "Gunbird 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Gunbird%202%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Gunbird%202.png",
     "region": "US",
     "description": "Forwarder installer for 05501000003e0000 and rom copier for roms/sdc/Gunbird 2.chd"
   },
   "0550100000410000": {
     "id": "0550100000410000",
     "name": "Gundam Battle Online - Trial Edition [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Gundam%20Battle%20Online%20-%20Trial%20Edition%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Gundam%20Battle%20Online%20-%20Trial%20Edition.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000400000 and rom copier for roms/sdc/Gundam Battle Online - Trial Edition.chd"
   },
   "0550100000430000": {
     "id": "0550100000430000",
     "name": "Gundam Battle Online [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Gundam%20Battle%20Online%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Gundam%20Battle%20Online.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000420000 and rom copier for roms/sdc/Gundam Battle Online.chd"
   },
   "0550100000450000": {
     "id": "0550100000450000",
     "name": "Gundam Side Story 0079 - Rise from the Ashes - Premium Disc [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Gundam%20Side%20Story%200079%20-%20Rise%20from%20the%20Ashes%20-%20Premium%20Disc%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Gundam%20Side%20Story%200079%20-%20Rise%20from%20the%20Ashes%20-%20Premium%20Disc.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000440000 and rom copier for roms/sdc/Gundam Side Story 0079 - Rise from the Ashes - Premium Disc.chd"
   },
   "0550100000470000": {
     "id": "0550100000470000",
     "name": "Gundam Side Story 0079 - Rise from the Ashes - Special Edition [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Gundam%20Side%20Story%200079%20-%20Rise%20from%20the%20Ashes%20-%20Special%20Edition%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Gundam%20Side%20Story%200079%20-%20Rise%20from%20the%20Ashes%20-%20Special%20Edition.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000460000 and rom copier for roms/sdc/Gundam Side Story 0079 - Rise from the Ashes - Special Edition.chd"
   },
   "0550100000490000": {
     "id": "0550100000490000",
     "name": "Gundam Side Story 0079 - Rise from the Ashes [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Gundam%20Side%20Story%200079%20-%20Rise%20from%20the%20Ashes%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Gundam%20Side%20Story%200079%20-%20Rise%20from%20the%20Ashes.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000480000 and rom copier for roms/sdc/Gundam Side Story 0079 - Rise from the Ashes.chd"
   },
   "05501000004B0000": {
     "id": "05501000004B0000",
     "name": "Gunspike [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Gunspike%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Gunspike.png",
     "region": "US",
     "description": "Forwarder installer for 05501000004a0000 and rom copier for roms/sdc/Gunspike.chd"
   },
   "05501000004D0000": {
     "id": "05501000004D0000",
     "name": "Guru Guru Onsen 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Guru%20Guru%20Onsen%202%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Guru%20Guru%20Onsen%202.png",
     "region": "US",
     "description": "Forwarder installer for 05501000004c0000 and rom copier for roms/sdc/Guru Guru Onsen 2.chd"
   },
   "05501000004F0000": {
     "id": "05501000004F0000",
     "name": "Guru Guru Onsen 3 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Guru%20Guru%20Onsen%203%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Guru%20Guru%20Onsen%203.png",
     "region": "US",
     "description": "Forwarder installer for 05501000004e0000 and rom copier for roms/sdc/Guru Guru Onsen 3.chd"
   },
   "0550100000510000": {
     "id": "0550100000510000",
     "name": "Happy Breeding [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Happy%20Breeding%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Happy%20Breeding.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000500000 and rom copier for roms/sdc/Happy Breeding.chd"
   },
   "0550100000530000": {
     "id": "0550100000530000",
     "name": "Happy Lesson - First Lesson [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Happy%20Lesson%20-%20First%20Lesson%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Happy%20Lesson%20-%20First%20Lesson.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000520000 and rom copier for roms/sdc/Happy Lesson - First Lesson.chd"
   },
   "0550100000550000": {
     "id": "0550100000550000",
     "name": "Happy Lesson [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Happy%20Lesson%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Happy%20Lesson.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000540000 and rom copier for roms/sdc/Happy Lesson.chd"
   },
   "0550100000570000": {
     "id": "0550100000570000",
     "name": "Harusame Youbi [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Harusame%20Youbi%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Harusame%20Youbi.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000560000 and rom copier for roms/sdc/Harusame Youbi.chd"
   },
   "0550100000590000": {
     "id": "0550100000590000",
     "name": "Headhunter Disc #1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Headhunter%20(Europe)%20(En,Fr,De,Es)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Headhunter%20Disc%20%231.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000580000 and rom copier for roms/sdc/Headhunter Disc #1.chd"
   },
   "05501000005B0000": {
     "id": "05501000005B0000",
     "name": "Headhunter Disc #2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Headhunter%20(Europe)%20(En,Fr,De,Es)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Headhunter%20Disc%20%232.png",
     "region": "US",
     "description": "Forwarder installer for 05501000005a0000 and rom copier for roms/sdc/Headhunter Disc #2.chd"
   },
   "05501000005D0000": {
     "id": "05501000005D0000",
     "name": "Heavy Metal - Geomatrix [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Heavy%20Metal%20-%20Geomatrix%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Heavy%20Metal%20-%20Geomatrix.png",
     "region": "US",
     "description": "Forwarder installer for 05501000005c0000 and rom copier for roms/sdc/Heavy Metal - Geomatrix.chd"
   },
   "05501000005F0000": {
     "id": "05501000005F0000",
     "name": "Heisei Mahjong-sou [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Heisei%20Mahjong-sou%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Heisei%20Mahjong-sou.png",
     "region": "US",
     "description": "Forwarder installer for 05501000005e0000 and rom copier for roms/sdc/Heisei Mahjong-sou.chd"
   },
   "0550100000610000": {
     "id": "0550100000610000",
     "name": "Hello Kitty no Dream Passport 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Hello%20Kitty%20no%20Garden%20Panic%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Hello%20Kitty%20no%20Garden%20Panic.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000600000 and rom copier for roms/sdc/Hello Kitty no Dream Passport 2.chd"
   },
   "0550100000630000": {
     "id": "0550100000630000",
     "name": "Hello Kitty no Garden Panic [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Hello%20Kitty%20no%20Garden%20Panic%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Hello%20Kitty%20no%20Garden%20Panic.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000620000 and rom copier for roms/sdc/Hello Kitty no Garden Panic.chd"
   },
   "0550100000650000": {
     "id": "0550100000650000",
     "name": "Hello Kitty no Lovely Fruit Park [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Hello%20Kitty%20no%20Lovely%20Fruit%20Park%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Hello%20Kitty%20no%20Lovely%20Fruit%20Park.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000640000 and rom copier for roms/sdc/Hello Kitty no Lovely Fruit Park.chd"
   },
   "0550100000670000": {
     "id": "0550100000670000",
     "name": "Hello Kitty no Magical Block [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Hello%20Kitty%20no%20Magical%20Block%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Hello%20Kitty%20no%20Magical%20Block.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000660000 and rom copier for roms/sdc/Hello Kitty no Magical Block.chd"
   },
   "0550100000690000": {
     "id": "0550100000690000",
     "name": "Hello Kitty no Otonaru Mail [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Hello%20Kitty%20no%20Otonaru%20Mail%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Hello%20Kitty%20no%20Otonaru%20Mail.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000680000 and rom copier for roms/sdc/Hello Kitty no Otonaru Mail.chd"
   },
   "05501000006B0000": {
     "id": "05501000006B0000",
     "name": "Hello Kitty no Waku Waku Cookies [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Hello%20Kitty%20no%20Waku%20Waku%20Cookies%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Hello%20Kitty%20no%20Waku%20Waku%20Cookies.png",
     "region": "US",
     "description": "Forwarder installer for 05501000006a0000 and rom copier for roms/sdc/Hello Kitty no Waku Waku Cookies.chd"
   },
   "05501000006D0000": {
     "id": "05501000006D0000",
     "name": "Heroes of Might and Magic III [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Hello%20Kitty%20no%20Magical%20Block%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Hello%20Kitty%20no%20Magical%20Block.png",
     "region": "US",
     "description": "Forwarder installer for 05501000006c0000 and rom copier for roms/sdc/Heroes of Might and Magic III.chd"
   },
   "05501000006F0000": {
     "id": "05501000006F0000",
     "name": "Hidden & Dangerous [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Hidden%20_%20Dangerous%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Hidden%20%26%20Dangerous.png",
     "region": "US",
     "description": "Forwarder installer for 05501000006e0000 and rom copier for roms/sdc/Hidden & Dangerous.chd"
   },
   "0550100000710000": {
     "id": "0550100000710000",
     "name": "Himitsu - Yui ga Ita Natsu [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Himitsu%20-%20Yui%20ga%20Ita%20Natsu%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Himitsu%20-%20Yui%20ga%20Ita%20Natsu.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000700000 and rom copier for roms/sdc/Himitsu - Yui ga Ita Natsu.chd"
   },
   "0550100000730000": {
     "id": "0550100000730000",
     "name": "Hoyle Casino [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Hoyle%20Casino%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Hoyle%20Casino.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000720000 and rom copier for roms/sdc/Hoyle Casino.chd"
   },
   "0550100000750000": {
     "id": "0550100000750000",
     "name": "Hundred Swords [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Hundred%20Swords%20(Japan)%20(@barai).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Hundred%20Swords.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000740000 and rom copier for roms/sdc/Hundred Swords.chd"
   },
   "0550100000770000": {
     "id": "0550100000770000",
     "name": "Hydro Thunder [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Hydro%20Thunder%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Hydro%20Thunder.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000760000 and rom copier for roms/sdc/Hydro Thunder.chd"
   },
   "0550100000790000": {
     "id": "0550100000790000",
     "name": "Idol Janshi o Tsukucchaou [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Idol%20Janshi%20o%20Tsukucchaou%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Idol%20Janshi%20o%20Tsukucchaou.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000780000 and rom copier for roms/sdc/Idol Janshi o Tsukucchaou.chd"
   },
   "05501000007B0000": {
     "id": "05501000007B0000",
     "name": "Ikaruga [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ikaruga%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ikaruga.png",
     "region": "US",
     "description": "Forwarder installer for 05501000007a0000 and rom copier for roms/sdc/Ikaruga.chd"
   },
   "05501000007D0000": {
     "id": "05501000007D0000",
     "name": "Illbleed [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Illbleed%20(Japan)%20(En,Ja).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Illbleed.png",
     "region": "US",
     "description": "Forwarder installer for 05501000007c0000 and rom copier for roms/sdc/Illbleed.chd"
   },
   "05501000007F0000": {
     "id": "05501000007F0000",
     "name": "Imakoso!! Dreamcast with Special GD!! [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Mahjong%20Taikai%20II%20Special%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Mahjong%20Taikai%20II%20Special.png",
     "region": "US",
     "description": "Forwarder installer for 05501000007e0000 and rom copier for roms/sdc/Imakoso!! Dreamcast with Special GD!!.chd"
   },
   "0550100000810000": {
     "id": "0550100000810000",
     "name": "Imperial no Taka - Fighter of Zero [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Imperial%20no%20Taka%20-%20Fighter%20of%20Zero%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Imperial%20no%20Taka%20-%20Fighter%20of%20Zero.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000800000 and rom copier for roms/sdc/Imperial no Taka - Fighter of Zero.chd"
   },
   "0550100000830000": {
     "id": "0550100000830000",
     "name": "Incoming - Jinrui Saishuu Kessen [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Incoming%20-%20Jinrui%20Saishuu%20Kessen%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Incoming%20-%20Jinrui%20Saishuu%20Kessen.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000820000 and rom copier for roms/sdc/Incoming - Jinrui Saishuu Kessen.chd"
   },
   "0550100000850000": {
     "id": "0550100000850000",
     "name": "Incoming [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Incoming%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Incoming.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000840000 and rom copier for roms/sdc/Incoming.chd"
   },
   "0550100000870000": {
     "id": "0550100000870000",
     "name": "Industrial Spy - Operation Espionage [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Industrial%20Spy%20-%20Operation%20Espionage%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Industrial%20Spy%20-%20Operation%20Espionage.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000860000 and rom copier for roms/sdc/Industrial Spy - Operation Espionage.chd"
   },
   "0550100000890000": {
     "id": "0550100000890000",
     "name": "Inoue Ryouko - Last Scene [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Inoue%20Ryouko%20-%20Last%20Scene%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Inoue%20Ryouko%20-%20Last%20Scene.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000880000 and rom copier for roms/sdc/Inoue Ryouko - Last Scene.chd"
   },
   "05501000008B0000": {
     "id": "05501000008B0000",
     "name": "Inoue Ryouko - Roommate [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Inoue%20Ryouko%20-%20Roommate%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Inoue%20Ryouko%20-%20Roommate.png",
     "region": "US",
     "description": "Forwarder installer for 05501000008a0000 and rom copier for roms/sdc/Inoue Ryouko - Roommate.chd"
   },
   "05501000008D0000": {
     "id": "05501000008D0000",
     "name": "Interlude [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Interlude%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Interlude.png",
     "region": "US",
     "description": "Forwarder installer for 05501000008c0000 and rom copier for roms/sdc/Interlude.chd"
   },
   "05501000008F0000": {
     "id": "05501000008F0000",
     "name": "Internet Browser V3.0 for Dreamcast [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jinsei%20Game%20for%20Dreamcast%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jinsei%20Game%20for%20Dreamcast.png",
     "region": "US",
     "description": "Forwarder installer for 05501000008e0000 and rom copier for roms/sdc/Internet Browser V3.0 for Dreamcast.chd"
   },
   "0550100000910000": {
     "id": "0550100000910000",
     "name": "Iris [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Iris%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Iris.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000900000 and rom copier for roms/sdc/Iris.chd"
   },
   "0550100000930000": {
     "id": "0550100000930000",
     "name": "Iron Aces [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Iron%20Aces%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Iron%20Aces.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000920000 and rom copier for roms/sdc/Iron Aces.chd"
   },
   "0550100000950000": {
     "id": "0550100000950000",
     "name": "Izumo [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Izumo%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Izumo.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000940000 and rom copier for roms/sdc/Izumo.chd"
   },
   "0550100000970000": {
     "id": "0550100000970000",
     "name": "J.League Pro Soccer Club o Tsukurou! [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/J.League%20Pro%20Soccer%20Club%20o%20Tsukurou!%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/J.League%20Pro%20Soccer%20Club%20o%20Tsukurou!.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000960000 and rom copier for roms/sdc/J.League Pro Soccer Club o Tsukurou!.chd"
   },
   "0550100000990000": {
     "id": "0550100000990000",
     "name": "J.League Spectacle Soccer [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/J.League%20Spectacle%20Soccer%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/J.League%20Spectacle%20Soccer.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000980000 and rom copier for roms/sdc/J.League Spectacle Soccer.chd"
   },
   "05501000009B0000": {
     "id": "05501000009B0000",
     "name": "Jahmong [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jahmong%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jahmong.png",
     "region": "US",
     "description": "Forwarder installer for 05501000009a0000 and rom copier for roms/sdc/Jahmong.chd"
   },
   "05501000009D0000": {
     "id": "05501000009D0000",
     "name": "Jeremy McGrath Supercross 2000 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jeremy%20McGrath%20Supercross%202000%20(Europe)%20(En,Fr,De).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jeremy%20McGrath%20Supercross%202000.png",
     "region": "US",
     "description": "Forwarder installer for 05501000009c0000 and rom copier for roms/sdc/Jeremy McGrath Supercross 2000.chd"
   },
   "05501000009F0000": {
     "id": "05501000009F0000",
     "name": "Jet Coaster Dream 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jet%20Coaster%20Dream%202%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jet%20Coaster%20Dream%202.png",
     "region": "US",
     "description": "Forwarder installer for 05501000009e0000 and rom copier for roms/sdc/Jet Coaster Dream 2.chd"
   },
   "0550100000A10000": {
     "id": "0550100000A10000",
     "name": "Jet Coaster Dream [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jet%20Coaster%20Dream%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jet%20Coaster%20Dream.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000a00000 and rom copier for roms/sdc/Jet Coaster Dream.chd"
   },
   "0550100000A30000": {
     "id": "0550100000A30000",
     "name": "Jet Grind Radio [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jet%20Grind%20Radio%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jet%20Grind%20Radio.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000a20000 and rom copier for roms/sdc/Jet Grind Radio.chd"
   },
   "0550100000A50000": {
     "id": "0550100000A50000",
     "name": "Jet Set Radio [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jet%20Set%20Radio%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jet%20Set%20Radio.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000a40000 and rom copier for roms/sdc/Jet Set Radio.chd"
   },
   "0550100000A70000": {
     "id": "0550100000A70000",
     "name": "Jikkyou Powerful Pro Yakyuu - Dreamcast Edition [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jikkyou%20Powerful%20Pro%20Yakyuu%20-%20Dreamcast%20Edition%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jikkyou%20Powerful%20Pro%20Yakyuu%20-%20Dreamcast%20Edition.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000a60000 and rom copier for roms/sdc/Jikkyou Powerful Pro Yakyuu - Dreamcast Edition.chd"
   },
   "0550100000A90000": {
     "id": "0550100000A90000",
     "name": "Jimmy White's 2 - Cueball [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jimmy%20White's%202%20-%20Cueball%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jimmy%20White's%202%20-%20Cueball.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000a80000 and rom copier for roms/sdc/Jimmy White's 2 - Cueball.chd"
   },
   "0550100000AB0000": {
     "id": "0550100000AB0000",
     "name": "Jinsei Game for Dreamcast [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jinsei%20Game%20for%20Dreamcast%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jinsei%20Game%20for%20Dreamcast.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000aa0000 and rom copier for roms/sdc/Jinsei Game for Dreamcast.chd"
   },
   "0550100000AD0000": {
     "id": "0550100000AD0000",
     "name": "Jissen Pachi-Slot Hisshouhou! @ VP@CHI - Kongdom [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jissen%20Pachi-Slot%20Hisshouhou!%20@%20VP@CHI%20-%20Kongdom%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jissen%20Pachi-Slot%20Hisshouhou!%20@%20VP@CHI%20-%20Kongdom.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000ac0000 and rom copier for roms/sdc/Jissen Pachi-Slot Hisshouhou! @ VP@CHI - Kongdom.chd"
   },
   "0550100000AF0000": {
     "id": "0550100000AF0000",
     "name": "Jojo no Kimyou na Bouken - Mirai e no Isan (1) [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jojo%20no%20Kimyou%20na%20Bouken%20-%20Mirai%20e%20no%20Isan%20(Japan)%20(Tentou%20Taikenban).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jojo%20no%20Kimyou%20na%20Bouken%20-%20Mirai%20e%20no%20Isan.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000ae0000 and rom copier for roms/sdc/Jojo no Kimyou na Bouken - Mirai e no Isan (1).chd"
   },
   "0550100000B10000": {
     "id": "0550100000B10000",
     "name": "Jojo no Kimyou na Bouken - Mirai e no Isan for Matching Service [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jojo%20no%20Kimyou%20na%20Bouken%20-%20Mirai%20e%20no%20Isan%20for%20Matching%20Service%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jojo%20no%20Kimyou%20na%20Bouken%20-%20Mirai%20e%20no%20Isan%20for%20Matching%20Service.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000b00000 and rom copier for roms/sdc/Jojo no Kimyou na Bouken - Mirai e no Isan for Matching Service.chd"
   },
   "0550100000B30000": {
     "id": "0550100000B30000",
     "name": "Jojo no Kimyou na Bouken - Mirai e no Isan [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jojo%20no%20Kimyou%20na%20Bouken%20-%20Mirai%20e%20no%20Isan%20(Japan)%20(Tentou%20Taikenban).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jojo%20no%20Kimyou%20na%20Bouken%20-%20Mirai%20e%20no%20Isan.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000b20000 and rom copier for roms/sdc/Jojo no Kimyou na Bouken - Mirai e no Isan.chd"
   },
   "0550100000B50000": {
     "id": "0550100000B50000",
     "name": "JoJo's Bizarre Adventure [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/JoJo's%20Bizarre%20Adventure%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/JoJo's%20Bizarre%20Adventure.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000b40000 and rom copier for roms/sdc/JoJo's Bizarre Adventure.chd"
   },
   "0550100000B70000": {
     "id": "0550100000B70000",
     "name": "JRA PAT for Dreamcast V40L10 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jinsei%20Game%20for%20Dreamcast%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jinsei%20Game%20for%20Dreamcast.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000b60000 and rom copier for roms/sdc/JRA PAT for Dreamcast V40L10.chd"
   },
   "0550100000B90000": {
     "id": "0550100000B90000",
     "name": "JRA PAT for Dreamcast V40L11 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jinsei%20Game%20for%20Dreamcast%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jinsei%20Game%20for%20Dreamcast.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000b80000 and rom copier for roms/sdc/JRA PAT for Dreamcast V40L11.chd"
   },
   "0550100000BB0000": {
     "id": "0550100000BB0000",
     "name": "JRA PAT for Dreamcast V50L10 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jinsei%20Game%20for%20Dreamcast%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jinsei%20Game%20for%20Dreamcast.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000ba0000 and rom copier for roms/sdc/JRA PAT for Dreamcast V50L10.chd"
   },
   "0550100000BD0000": {
     "id": "0550100000BD0000",
     "name": "July [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/July%20(Japan)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/July.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000bc0000 and rom copier for roms/sdc/July.chd"
   },
   "0550100000BF0000": {
     "id": "0550100000BF0000",
     "name": "Kaen Seibo - The Virgin on Megiddo Disc #1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kaen%20Seibo%20-%20The%20Virgin%20on%20Megiddo%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kaen%20Seibo%20-%20The%20Virgin%20on%20Megiddo%20Disc%20%231.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000be0000 and rom copier for roms/sdc/Kaen Seibo - The Virgin on Megiddo Disc #1.chd"
   },
   "0550100000C10000": {
     "id": "0550100000C10000",
     "name": "Kaen Seibo - The Virgin on Megiddo Disc #2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kaen%20Seibo%20-%20The%20Virgin%20on%20Megiddo%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kaen%20Seibo%20-%20The%20Virgin%20on%20Megiddo%20Disc%20%232.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000c00000 and rom copier for roms/sdc/Kaen Seibo - The Virgin on Megiddo Disc #2.chd"
   },
   "0550100000C30000": {
     "id": "0550100000C30000",
     "name": "Kaitou Apricot [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kaitou%20Apricot%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kaitou%20Apricot.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000c20000 and rom copier for roms/sdc/Kaitou Apricot.chd"
   },
   "0550100000C50000": {
     "id": "0550100000C50000",
     "name": "Kanon [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kanon%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kanon.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000c40000 and rom copier for roms/sdc/Kanon.chd"
   },
   "0550100000C70000": {
     "id": "0550100000C70000",
     "name": "Kao the Kangaroo Demo [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kao%20the%20Kangaroo%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kao%20the%20Kangaroo.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000c60000 and rom copier for roms/sdc/Kao the Kangaroo Demo.chd"
   },
   "0550100000C90000": {
     "id": "0550100000C90000",
     "name": "Kao the Kangaroo [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kao%20the%20Kangaroo%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kao%20the%20Kangaroo.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000c80000 and rom copier for roms/sdc/Kao the Kangaroo.chd"
   },
   "0550100000CB0000": {
     "id": "0550100000CB0000",
     "name": "Karous [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Karous%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Karous.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000ca0000 and rom copier for roms/sdc/Karous.chd"
   },
   "0550100000CD0000": {
     "id": "0550100000CD0000",
     "name": "Kaze no Uta [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Daytona%20USA%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Daytona%20USA.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000cc0000 and rom copier for roms/sdc/Kaze no Uta.chd"
   },
   "0550100000CF0000": {
     "id": "0550100000CF0000",
     "name": "Kidou Senkan Nadesico - Nadesico the Mission [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kidou%20Senkan%20Nadesico%20-%20Nadesico%20the%20Mission%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kidou%20Senkan%20Nadesico%20-%20Nadesico%20the%20Mission.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000ce0000 and rom copier for roms/sdc/Kidou Senkan Nadesico - Nadesico the Mission.chd"
   },
   "0550100000D10000": {
     "id": "0550100000D10000",
     "name": "Kidou Senshi Gundam - Gihren no Yabou - Zeon no Keifu Disc #1 Earth Federation Disc [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kidou%20Senshi%20Gundam%20-%20Gihren%20no%20Yabou%20-%20Zeon%20no%20Keifu%20(Japan)%20(Disc%201)%20(Earth%20Federation%20Disc).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kidou%20Senshi%20Gundam%20-%20Gihren%20no%20Yabou%20-%20Zeon%20no%20Keifu%20Disc%20%231%20Earth%20Federation%20Disc.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000d00000 and rom copier for roms/sdc/Kidou Senshi Gundam - Gihren no Yabou - Zeon no Keifu Disc #1 Earth Federation Disc.chd"
   },
   "0550100000D30000": {
     "id": "0550100000D30000",
     "name": "Kidou Senshi Gundam - Gihren no Yabou - Zeon no Keifu Disc #2 Zeon Disc [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kidou%20Senshi%20Gundam%20-%20Gihren%20no%20Yabou%20-%20Zeon%20no%20Keifu%20(Japan)%20(Disc%201)%20(Earth%20Federation%20Disc).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kidou%20Senshi%20Gundam%20-%20Gihren%20no%20Yabou%20-%20Zeon%20no%20Keifu%20Disc%20%232%20Zeon%20Disc.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000d20000 and rom copier for roms/sdc/Kidou Senshi Gundam - Gihren no Yabou - Zeon no Keifu Disc #2 Zeon Disc.chd"
   },
   "0550100000D50000": {
     "id": "0550100000D50000",
     "name": "Kidou Senshi Gundam - Renpou vs. Zeon & DX Disc #1 Kidou Senshi Gundam - Renpou vs. Zeon [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kidou%20Senshi%20Gundam%20-%20Renpou%20vs.%20Zeon%20_%20DX%20(Japan)%20(Disc%201)%20(Kidou%20Senshi%20Gundam%20-%20Renpou%20vs.%20Zeon).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kidou%20Senshi%20Gundam%20-%20Renpou%20vs.%20Zeon%20%26%20DX%20Disc%20%231%20Kidou%20Senshi%20Gundam%20-%20Renpou%20vs.%20Zeon.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000d40000 and rom copier for roms/sdc/Kidou Senshi Gundam - Renpou vs. Zeon & DX Disc #1 Kidou Senshi Gundam - Renpou vs. Zeon.chd"
   },
   "0550100000D70000": {
     "id": "0550100000D70000",
     "name": "Kidou Senshi Gundam - Renpou vs. Zeon & DX Disc #2 Kidou Senshi Gundam - Renpou vs. Zeon DX [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kidou%20Senshi%20Gundam%20-%20Renpou%20vs.%20Zeon%20_%20DX%20(Japan)%20(Disc%201)%20(Kidou%20Senshi%20Gundam%20-%20Renpou%20vs.%20Zeon).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kidou%20Senshi%20Gundam%20-%20Renpou%20vs.%20Zeon%20%26%20DX%20Disc%20%232%20Kidou%20Senshi%20Gundam%20-%20Renpou%20vs.%20Zeon%20DX.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000d60000 and rom copier for roms/sdc/Kidou Senshi Gundam - Renpou vs. Zeon & DX Disc #2 Kidou Senshi Gundam - Renpou vs. Zeon DX.chd"
   },
   "0550100000D90000": {
     "id": "0550100000D90000",
     "name": "Kimi ga Nozomu Eien [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kimi%20ga%20Nozomu%20Eien%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kimi%20ga%20Nozomu%20Eien.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000d80000 and rom copier for roms/sdc/Kimi ga Nozomu Eien.chd"
   },
   "0550100000DB0000": {
     "id": "0550100000DB0000",
     "name": "Kindan no Pet - Seaman - Gaze Hakase no Jikken-tou  Rev A [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Nanatsu%20no%20Hikan%20-%20Senritsu%20no%20Bishou%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Nanatsu%20no%20Hikan%20-%20Senritsu%20no%20Bishou.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000da0000 and rom copier for roms/sdc/Kindan no Pet - Seaman - Gaze Hakase no Jikken-tou  Rev A.chd"
   },
   "0550100000DD0000": {
     "id": "0550100000DD0000",
     "name": "Kindan no Pet - Seaman - Gaze Hakase no Jikken-tou 2001-nen Taiouban Rev A [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kidou%20Senshi%20Gundam%20-%20Gihren%20no%20Yabou%20-%20Zeon%20no%20Keifu%20(Japan)%20(Disc%201)%20(Earth%20Federation%20Disc).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kindan%20no%20Pet%20-%20Seaman%20-%20Gaze%20Hakase%20no%20Jikken-tou%20Rev%20A.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000dc0000 and rom copier for roms/sdc/Kindan no Pet - Seaman - Gaze Hakase no Jikken-tou 2001-nen Taiouban Rev A.chd"
   },
   "0550100000DF0000": {
     "id": "0550100000DF0000",
     "name": "King of Fighters, The - Dream Match 1999 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/King%20of%20Fighters,%20The%20-%20Dream%20Match%201999%20(Japan)%20(En,Ja,Es,Pt).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/King%20of%20Fighters%2C%20The%20-%20Dream%20Match%201999.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000de0000 and rom copier for roms/sdc/King of Fighters, The - Dream Match 1999.chd"
   },
   "0550100000E10000": {
     "id": "0550100000E10000",
     "name": "King of Fighters, The - Evolution [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/King%20of%20Fighters,%20The%20-%20Evolution%20(USA)%20(En,Ja,Es,Pt).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/King%20of%20Fighters,%20The%20-%20Evolution.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000e00000 and rom copier for roms/sdc/King of Fighters, The - Evolution.chd"
   },
   "0550100000E30000": {
     "id": "0550100000E30000",
     "name": "KISS Psycho Circus - The Nightmare Child [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/KISS%20Psycho%20Circus%20-%20The%20Nightmare%20Child%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/KISS%20Psycho%20Circus%20-%20The%20Nightmare%20Child.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000e20000 and rom copier for roms/sdc/KISS Psycho Circus - The Nightmare Child.chd"
   },
   "0550100000E50000": {
     "id": "0550100000E50000",
     "name": "Kita e. Photo Memories [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kita%20e.%20Photo%20Memories%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kita%20e.%20Photo%20Memories.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000e40000 and rom copier for roms/sdc/Kita e. Photo Memories.chd"
   },
   "0550100000E70000": {
     "id": "0550100000E70000",
     "name": "Kita e. White Illumination [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kita%20e.%20White%20Illumination%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kita%20e.%20White%20Illumination.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000e60000 and rom copier for roms/sdc/Kita e. White Illumination.chd"
   },
   "0550100000E90000": {
     "id": "0550100000E90000",
     "name": "Kitahei Gold [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kitahei%20Gold%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kitahei%20Gold.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000e80000 and rom copier for roms/sdc/Kitahei Gold.chd"
   },
   "0550100000EB0000": {
     "id": "0550100000EB0000",
     "name": "Kiteretsu Boy's Gangagan [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kiteretsu%20Boy's%20Gangagan%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kiteretsu%20Boy's%20Gangagan.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000ea0000 and rom copier for roms/sdc/Kiteretsu Boy's Gangagan.chd"
   },
   "0550100000ED0000": {
     "id": "0550100000ED0000",
     "name": "Konohana - True Report [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Konohana%20-%20True%20Report%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Konohana%20-%20True%20Report.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000ec0000 and rom copier for roms/sdc/Konohana - True Report.chd"
   },
   "0550100000EF0000": {
     "id": "0550100000EF0000",
     "name": "Konohana 2 - Todokanai Requiem [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Konohana%202%20-%20Todokanai%20Requiem%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Konohana%202%20-%20Todokanai%20Requiem.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000ee0000 and rom copier for roms/sdc/Konohana 2 - Todokanai Requiem.chd"
   },
   "0550100000F10000": {
     "id": "0550100000F10000",
     "name": "Kuon no Kizuna - Sairinshou [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kuon%20no%20Kizuna%20-%20Sairinshou%20(Japan)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Kuon%20no%20Kizuna%20-%20Sairinshou.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000f00000 and rom copier for roms/sdc/Kuon no Kizuna - Sairinshou.chd"
   },
   "0550100000F30000": {
     "id": "0550100000F30000",
     "name": "L.O.L. - Lack of Love [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/L.O.L.%20-%20Lack%20of%20Love%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/L.O.L.%20-%20Lack%20of%20Love.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000f20000 and rom copier for roms/sdc/L.O.L. - Lack of Love.chd"
   },
   "0550100000F50000": {
     "id": "0550100000F50000",
     "name": "Lake Masters Pro - Dreamcast Plus! [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Lake%20Masters%20Pro%20-%20Dreamcast%20Plus!%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Lake%20Masters%20Pro%20-%20Dreamcast%20Plus!.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000f40000 and rom copier for roms/sdc/Lake Masters Pro - Dreamcast Plus!.chd"
   },
   "0550100000F70000": {
     "id": "0550100000F70000",
     "name": "Langrisser Millennium [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Langrisser%20Millennium%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Langrisser%20Millennium.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000f60000 and rom copier for roms/sdc/Langrisser Millennium.chd"
   },
   "0550100000F90000": {
     "id": "0550100000F90000",
     "name": "Last Blade 2, The - Heart of the Samurai [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Last%20Blade%202,%20The%20-%20Heart%20of%20the%20Samurai%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Last%20Blade%202,%20The%20-%20Heart%20of%20the%20Samurai.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000f80000 and rom copier for roms/sdc/Last Blade 2, The - Heart of the Samurai.chd"
   },
   "0550100000FB0000": {
     "id": "0550100000FB0000",
     "name": "Le Mans 24 Hours [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Le%20Mans%2024%20Hours%20(Europe)%20(En,Fr,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Le%20Mans%2024%20Hours.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000fa0000 and rom copier for roms/sdc/Le Mans 24 Hours.chd"
   },
   "0550100000FD0000": {
     "id": "0550100000FD0000",
     "name": "Legacy of Kain - Soul Reaver [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Legacy%20of%20Kain%20-%20Soul%20Reaver%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Legacy%20of%20Kain%20-%20Soul%20Reaver.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000fc0000 and rom copier for roms/sdc/Legacy of Kain - Soul Reaver.chd"
   },
   "0550100000FF0000": {
     "id": "0550100000FF0000",
     "name": "Looney Tunes - Space Race [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Looney%20Tunes%20-%20Space%20Race%20(Europe)%20(En,Fr,De,Es,It,Nl).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Looney%20Tunes%20-%20Space%20Race.png",
     "region": "US",
     "description": "Forwarder installer for 0550100000fe0000 and rom copier for roms/sdc/Looney Tunes - Space Race.chd"
   },
   "0550100001010000": {
     "id": "0550100001010000",
     "name": "Love Hina - Smile Again [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Love%20Hina%20-%20Smile%20Again%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Love%20Hina%20-%20Smile%20Again.png",
     "region": "US",
     "description": "Forwarder installer for 0550100001000000 and rom copier for roms/sdc/Love Hina - Smile Again.chd"
   },
   "0550100001030000": {
     "id": "0550100001030000",
     "name": "Love Hina - Totsuzen no Engage Happening [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Love%20Hina%20-%20Totsuzen%20no%20Engage%20Happening%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Love%20Hina%20-%20Totsuzen%20no%20Engage%20Happening.png",
     "region": "US",
     "description": "Forwarder installer for 0550100001020000 and rom copier for roms/sdc/Love Hina - Totsuzen no Engage Happening.chd"
   },
   "0550200000010000": {
     "id": "0550200000010000",
     "name": "Maboroshi Tsukiyo Taikenban [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Maboroshi%20Tsukiyo%20(Japan)%20(Taikenban).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Maboroshi%20Tsukiyo.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000000000 and rom copier for roms/sdc/Maboroshi Tsukiyo Taikenban.chd"
   },
   "0550200000030000": {
     "id": "0550200000030000",
     "name": "Maboroshi Tsukiyo [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Maboroshi%20Tsukiyo%20(Japan)%20(Taikenban).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Maboroshi%20Tsukiyo.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000020000 and rom copier for roms/sdc/Maboroshi Tsukiyo.chd"
   },
   "0550200000050000": {
     "id": "0550200000050000",
     "name": "Macross M3 Demo [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Macross%20M3%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Macross%20M3.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000040000 and rom copier for roms/sdc/Macross M3 Demo.chd"
   },
   "0550200000070000": {
     "id": "0550200000070000",
     "name": "Macross M3 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Macross%20M3%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Macross%20M3.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000060000 and rom copier for roms/sdc/Macross M3.chd"
   },
   "0550200000090000": {
     "id": "0550200000090000",
     "name": "MagForce Racing [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/MagForce%20Racing%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/MagForce%20Racing.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000080000 and rom copier for roms/sdc/MagForce Racing.chd"
   },
   "05502000000B0000": {
     "id": "05502000000B0000",
     "name": "Magic - The Gathering [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Magic%20-%20The%20Gathering%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Magic%20-%20The%20Gathering.png",
     "region": "US",
     "description": "Forwarder installer for 05502000000a0000 and rom copier for roms/sdc/Magic - The Gathering.chd"
   },
   "05502000000D0000": {
     "id": "05502000000D0000",
     "name": "Mahjong Taikai II Special [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Mahjong%20Taikai%20II%20Special%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Mahjong%20Taikai%20II%20Special.png",
     "region": "US",
     "description": "Forwarder installer for 05502000000c0000 and rom copier for roms/sdc/Mahjong Taikai II Special.chd"
   },
   "05502000000F0000": {
     "id": "05502000000F0000",
     "name": "Majo no Ocha-kai [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Majo%20no%20Ocha-kai%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Majo%20no%20Ocha-kai.png",
     "region": "US",
     "description": "Forwarder installer for 05502000000e0000 and rom copier for roms/sdc/Majo no Ocha-kai.chd"
   },
   "0550200000110000": {
     "id": "0550200000110000",
     "name": "Maken X [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Maken%20X%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Maken%20X.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000100000 and rom copier for roms/sdc/Maken X.chd"
   },
   "0550200000130000": {
     "id": "0550200000130000",
     "name": "Margi - Marginal [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Margi%20-%20Marginal%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Margi%20-%20Marginal.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000120000 and rom copier for roms/sdc/Margi - Marginal.chd"
   },
   "0550200000150000": {
     "id": "0550200000150000",
     "name": "Marie & Elie no Atelier - Salburg no Renkinjutsushi 1 & 2 Game Disc [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Marie%20_%20Elie%20no%20Atelier%20-%20Salburg%20no%20Renkinjutsushi%201%20_%202%20(Japan)%20(Game%20Disc)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Marie%20%26%20Elie%20no%20Atelier%20-%20Salburg%20no%20Renkinjutsushi%201%20%26%202%20Game%20Disc.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000140000 and rom copier for roms/sdc/Marie & Elie no Atelier - Salburg no Renkinjutsushi 1 & 2 Game Disc.chd"
   },
   "0550200000170000": {
     "id": "0550200000170000",
     "name": "Marie & Elie no Atelier - Salburg no Renkinjutsushi 1 & 2 Omake Disc [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Marie%20_%20Elie%20no%20Atelier%20-%20Salburg%20no%20Renkinjutsushi%201%20_%202%20(Japan)%20(Game%20Disc)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Marie%20%26%20Elie%20no%20Atelier%20-%20Salburg%20no%20Renkinjutsushi%201%20%26%202%20Game%20Disc.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000160000 and rom copier for roms/sdc/Marie & Elie no Atelier - Salburg no Renkinjutsushi 1 & 2 Omake Disc.chd"
   },
   "0550200000190000": {
     "id": "0550200000190000",
     "name": "Marionette Company 2 Chu! [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Marionette%20Company%202%20Chu!%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Marionette%20Company%202%20Chu!.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000180000 and rom copier for roms/sdc/Marionette Company 2 Chu!.chd"
   },
   "05502000001B0000": {
     "id": "05502000001B0000",
     "name": "Marionette Company [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Marionette%20Company%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Marionette%20Company.png",
     "region": "US",
     "description": "Forwarder installer for 05502000001a0000 and rom copier for roms/sdc/Marionette Company.chd"
   },
   "05502000001D0000": {
     "id": "05502000001D0000",
     "name": "Marionette Handler 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Marionette%20Handler%202%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Marionette%20Handler%202.png",
     "region": "US",
     "description": "Forwarder installer for 05502000001c0000 and rom copier for roms/sdc/Marionette Handler 2.chd"
   },
   "05502000001F0000": {
     "id": "05502000001F0000",
     "name": "Marionette Handler [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Marionette%20Handler%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Marionette%20Handler.png",
     "region": "US",
     "description": "Forwarder installer for 05502000001e0000 and rom copier for roms/sdc/Marionette Handler.chd"
   },
   "0550200000210000": {
     "id": "0550200000210000",
     "name": "Mars Matrix [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Mars%20Matrix%20(Japan)%20(En,Ja).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Mars%20Matrix.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000200000 and rom copier for roms/sdc/Mars Matrix.chd"
   },
   "0550200000230000": {
     "id": "0550200000230000",
     "name": "Marvel vs. Capcom - Clash of Super Heroes [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Marvel%20vs.%20Capcom%20-%20Clash%20of%20Super%20Heroes%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Marvel%20vs.%20Capcom%20-%20Clash%20of%20Super%20Heroes.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000220000 and rom copier for roms/sdc/Marvel vs. Capcom - Clash of Super Heroes.chd"
   },
   "0550200000250000": {
     "id": "0550200000250000",
     "name": "Marvel vs. Capcom 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Marvel%20vs.%20Capcom%202%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Marvel%20vs.%20Capcom%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000240000 and rom copier for roms/sdc/Marvel vs. Capcom 2.chd"
   },
   "0550200000270000": {
     "id": "0550200000270000",
     "name": "Mat Hoffman's Pro BMX [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Mat%20Hoffman's%20Pro%20BMX%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Mat%20Hoffman's%20Pro%20BMX.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000260000 and rom copier for roms/sdc/Mat Hoffman's Pro BMX.chd"
   },
   "0550200000290000": {
     "id": "0550200000290000",
     "name": "Max Steel - Covert Missions [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Max%20Steel%20-%20Covert%20Missions%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Max%20Steel%20-%20Covert%20Missions.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000280000 and rom copier for roms/sdc/Max Steel - Covert Missions.chd"
   },
   "05502000002B0000": {
     "id": "05502000002B0000",
     "name": "Maximum Pool [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Maximum%20Pool%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Maximum%20Pool.png",
     "region": "US",
     "description": "Forwarder installer for 05502000002a0000 and rom copier for roms/sdc/Maximum Pool.chd"
   },
   "05502000002D0000": {
     "id": "05502000002D0000",
     "name": "MDK2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/MDK2%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/MDK2.png",
     "region": "US",
     "description": "Forwarder installer for 05502000002c0000 and rom copier for roms/sdc/MDK2.chd"
   },
   "05502000002F0000": {
     "id": "05502000002F0000",
     "name": "Mei Puru [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Mei%20Puru%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Mei%20Puru.png",
     "region": "US",
     "description": "Forwarder installer for 05502000002e0000 and rom copier for roms/sdc/Mei Puru.chd"
   },
   "0550200000310000": {
     "id": "0550200000310000",
     "name": "Memories Off 2nd - Making Disc [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Memories%20Off%202nd%20-%20Making%20Disc%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Memories%20Off%202nd%20-%20Making%20Disc.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000300000 and rom copier for roms/sdc/Memories Off 2nd - Making Disc.chd"
   },
   "0550200000330000": {
     "id": "0550200000330000",
     "name": "Memories Off 2nd - Promotion Disc [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Memories%20Off%202nd%20-%20Promotion%20Disc%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Memories%20Off%202nd%20-%20Promotion%20Disc.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000320000 and rom copier for roms/sdc/Memories Off 2nd - Promotion Disc.chd"
   },
   "0550200000350000": {
     "id": "0550200000350000",
     "name": "Memories Off 2nd [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Memories%20Off%202nd%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Memories%20Off%202nd.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000340000 and rom copier for roms/sdc/Memories Off 2nd.chd"
   },
   "0550200000370000": {
     "id": "0550200000370000",
     "name": "Memories Off Complete [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Memories%20Off%20Complete%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Memories%20Off%20Complete.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000360000 and rom copier for roms/sdc/Memories Off Complete.chd"
   },
   "0550200000390000": {
     "id": "0550200000390000",
     "name": "Mercurius Pretty - End of the Century [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Mercurius%20Pretty%20-%20End%20of%20the%20Century%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Mercurius%20Pretty%20-%20End%20of%20the%20Century.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000380000 and rom copier for roms/sdc/Mercurius Pretty - End of the Century.chd"
   },
   "05502000003B0000": {
     "id": "05502000003B0000",
     "name": "Metal Wolf [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Metal%20Wolf%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Metal%20Wolf.png",
     "region": "US",
     "description": "Forwarder installer for 05502000003a0000 and rom copier for roms/sdc/Metal Wolf.chd"
   },
   "05502000003D0000": {
     "id": "05502000003D0000",
     "name": "Microsoft WebTV Setsuzoku Kit 128bit SSL Taiouban [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Microsoft%20WebTV%20Setsuzoku%20Kit%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Microsoft%20WebTV%20Setsuzoku%20Kit.png",
     "region": "US",
     "description": "Forwarder installer for 05502000003c0000 and rom copier for roms/sdc/Microsoft WebTV Setsuzoku Kit 128bit SSL Taiouban.chd"
   },
   "05502000003F0000": {
     "id": "05502000003F0000",
     "name": "Microsoft WebTV Setsuzoku Kit [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Microsoft%20WebTV%20Setsuzoku%20Kit%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Microsoft%20WebTV%20Setsuzoku%20Kit.png",
     "region": "US",
     "description": "Forwarder installer for 05502000003e0000 and rom copier for roms/sdc/Microsoft WebTV Setsuzoku Kit.chd"
   },
   "0550200000410000": {
     "id": "0550200000410000",
     "name": "Midway's Greatest Arcade Hits - Volume 1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Midway's%20Greatest%20Arcade%20Hits%20-%20Volume%201%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Midway's%20Greatest%20Arcade%20Hits%20-%20Volume%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000400000 and rom copier for roms/sdc/Midway's Greatest Arcade Hits - Volume 1.chd"
   },
   "0550200000430000": {
     "id": "0550200000430000",
     "name": "Midway's Greatest Arcade Hits - Volume 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Midway's%20Greatest%20Arcade%20Hits%20-%20Volume%202%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Midway's%20Greatest%20Arcade%20Hits%20-%20Volume%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000420000 and rom copier for roms/sdc/Midway's Greatest Arcade Hits - Volume 2.chd"
   },
   "0550200000450000": {
     "id": "0550200000450000",
     "name": "Milky Season [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Milky%20Season%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Milky%20Season.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000440000 and rom copier for roms/sdc/Milky Season.chd"
   },
   "0550200000470000": {
     "id": "0550200000470000",
     "name": "Millennium Soldier - Expendable [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Millennium%20Soldier%20-%20Expendable%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Millennium%20Soldier%20-%20Expendable.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000460000 and rom copier for roms/sdc/Millennium Soldier - Expendable.chd"
   },
   "0550200000490000": {
     "id": "0550200000490000",
     "name": "Miss Moonlight [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Miss%20Moonlight%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Miss%20Moonlight.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000480000 and rom copier for roms/sdc/Miss Moonlight.chd"
   },
   "05502000004B0000": {
     "id": "05502000004B0000",
     "name": "Missing Parts - The Tantei Stories [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Missing%20Parts%20-%20The%20Tantei%20Stories%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Missing%20Parts%20-%20The%20Tantei%20Stories.png",
     "region": "US",
     "description": "Forwarder installer for 05502000004a0000 and rom copier for roms/sdc/Missing Parts - The Tantei Stories.chd"
   },
   "05502000004D0000": {
     "id": "05502000004D0000",
     "name": "Missing Parts 2 - The Tantei Stories [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Missing%20Parts%202%20-%20The%20Tantei%20Stories%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Missing%20Parts%202%20-%20The%20Tantei%20Stories.png",
     "region": "US",
     "description": "Forwarder installer for 05502000004c0000 and rom copier for roms/sdc/Missing Parts 2 - The Tantei Stories.chd"
   },
   "05502000004F0000": {
     "id": "05502000004F0000",
     "name": "Missing Parts 3 - The Tantei Stories [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Missing%20Parts%203%20-%20The%20Tantei%20Stories%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Missing%20Parts%203%20-%20The%20Tantei%20Stories.png",
     "region": "US",
     "description": "Forwarder installer for 05502000004e0000 and rom copier for roms/sdc/Missing Parts 3 - The Tantei Stories.chd"
   },
   "0550200000510000": {
     "id": "0550200000510000",
     "name": "Mizuiro [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Mizuiro%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Mizuiro.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000500000 and rom copier for roms/sdc/Mizuiro.chd"
   },
   "0550200000530000": {
     "id": "0550200000530000",
     "name": "Moekan [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Moekan%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Moekan.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000520000 and rom copier for roms/sdc/Moekan.chd"
   },
   "0550200000550000": {
     "id": "0550200000550000",
     "name": "Moero! Justice Gakuen [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Moero!%20Justice%20Gakuen%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Moero!%20Justice%20Gakuen.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000540000 and rom copier for roms/sdc/Moero! Justice Gakuen.chd"
   },
   "0550200000570000": {
     "id": "0550200000570000",
     "name": "MoHo [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/MoHo%20(Europe)%20(En,Fr,De).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/MoHo.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000560000 and rom copier for roms/sdc/MoHo.chd"
   },
   "0550200000590000": {
     "id": "0550200000590000",
     "name": "Monaco Grand Prix Racing Simulation 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Monaco%20Grand%20Prix%20Racing%20Simulation%202%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Monaco%20Grand%20Prix%20Racing%20Simulation%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000580000 and rom copier for roms/sdc/Monaco Grand Prix Racing Simulation 2.chd"
   },
   "05502000005B0000": {
     "id": "05502000005B0000",
     "name": "Monaco Grand Prix [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Monaco%20Grand%20Prix%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Monaco%20Grand%20Prix.png",
     "region": "US",
     "description": "Forwarder installer for 05502000005a0000 and rom copier for roms/sdc/Monaco Grand Prix.chd"
   },
   "05502000005D0000": {
     "id": "05502000005D0000",
     "name": "Morita no Saikyou Reversi Tentou Taikenban [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Morita%20no%20Saikyou%20Reversi%20(Japan)%20(Tentou%20Taikenban).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Morita%20no%20Saikyou%20Reversi.png",
     "region": "US",
     "description": "Forwarder installer for 05502000005c0000 and rom copier for roms/sdc/Morita no Saikyou Reversi Tentou Taikenban.chd"
   },
   "05502000005F0000": {
     "id": "05502000005F0000",
     "name": "Morita no Saikyou Reversi [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Morita%20no%20Saikyou%20Reversi%20(Japan)%20(Tentou%20Taikenban).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Morita%20no%20Saikyou%20Reversi.png",
     "region": "US",
     "description": "Forwarder installer for 05502000005e0000 and rom copier for roms/sdc/Morita no Saikyou Reversi.chd"
   },
   "0550200000610000": {
     "id": "0550200000610000",
     "name": "Morita no Saikyou Shougi [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Morita%20no%20Saikyou%20Shougi%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Morita%20no%20Saikyou%20Shougi.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000600000 and rom copier for roms/sdc/Morita no Saikyou Shougi.chd"
   },
   "0550200000630000": {
     "id": "0550200000630000",
     "name": "Mortal Kombat Gold [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Mortal%20Kombat%20Gold%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Mortal%20Kombat%20Gold.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000620000 and rom copier for roms/sdc/Mortal Kombat Gold.chd"
   },
   "0550200000650000": {
     "id": "0550200000650000",
     "name": "Motto Pro Yakyuu Team o Tsukurou! [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Motto%20Pro%20Yakyuu%20Team%20o%20Tsukurou!%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Motto%20Pro%20Yakyuu%20Team%20o%20Tsukurou!.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000640000 and rom copier for roms/sdc/Motto Pro Yakyuu Team o Tsukurou!.chd"
   },
   "0550200000670000": {
     "id": "0550200000670000",
     "name": "Mr. Driller [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Mr.%20Driller%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Mr.%20Driller.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000660000 and rom copier for roms/sdc/Mr. Driller.chd"
   },
   "0550200000690000": {
     "id": "0550200000690000",
     "name": "Ms. Pac-Man Maze Madness [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ms.%20Pac-Man%20Maze%20Madness%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ms.%20Pac-Man%20Maze%20Madness.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000680000 and rom copier for roms/sdc/Ms. Pac-Man Maze Madness.chd"
   },
   "05502000006B0000": {
     "id": "05502000006B0000",
     "name": "MSR - Metropolis Street Racer [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/MSR%20-%20Metropolis%20Street%20Racer%20(Europe)%20(En,Fr,De,Es)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/MSR%20-%20Metropolis%20Street%20Racer.png",
     "region": "US",
     "description": "Forwarder installer for 05502000006a0000 and rom copier for roms/sdc/MSR - Metropolis Street Racer.chd"
   },
   "05502000006D0000": {
     "id": "05502000006D0000",
     "name": "MSR Opel Challenge Beta [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/F355%20Challenge%20(Japan)%20(Taikenban).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/MSR%20Opel%20Challenge%20Beta.png",
     "region": "US",
     "description": "Forwarder installer for 05502000006c0000 and rom copier for roms/sdc/MSR Opel Challenge Beta.chd"
   },
   "05502000006F0000": {
     "id": "05502000006F0000",
     "name": "MTV Sports - Skateboarding featuring Andy Macdonald [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/MTV%20Sports%20-%20Skateboarding%20featuring%20Andy%20Macdonald%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/MTV%20Sports%20-%20Skateboarding%20featuring%20Andy%20Macdonald.png",
     "region": "US",
     "description": "Forwarder installer for 05502000006e0000 and rom copier for roms/sdc/MTV Sports - Skateboarding featuring Andy Macdonald.chd"
   },
   "0550200000710000": {
     "id": "0550200000710000",
     "name": "Musapey's Choco Marker [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Musapey's%20Choco%20Marker%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Musapey's%20Choco%20Marker.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000700000 and rom copier for roms/sdc/Musapey's Choco Marker.chd"
   },
   "0550200000730000": {
     "id": "0550200000730000",
     "name": "My Merry May [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/My%20Merry%20May%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/My%20Merry%20May.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000720000 and rom copier for roms/sdc/My Merry May.chd"
   },
   "0550200000750000": {
     "id": "0550200000750000",
     "name": "My Merry Maybe Disc #1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/My%20Merry%20Maybe%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/My%20Merry%20Maybe%20Disc%20%231.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000740000 and rom copier for roms/sdc/My Merry Maybe Disc #1.chd"
   },
   "0550200000770000": {
     "id": "0550200000770000",
     "name": "My Merry Maybe Disc #2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/My%20Merry%20Maybe%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/My%20Merry%20Maybe%20Disc%20%232.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000760000 and rom copier for roms/sdc/My Merry Maybe Disc #2.chd"
   },
   "0550200000790000": {
     "id": "0550200000790000",
     "name": "Nakoruru - Ano Hito kara no Okurimono [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Nakoruru%20-%20Ano%20Hito%20kara%20no%20Okurimono%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Nakoruru%20-%20Ano%20Hito%20kara%20no%20Okurimono.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000780000 and rom copier for roms/sdc/Nakoruru - Ano Hito kara no Okurimono.chd"
   },
   "05502000007B0000": {
     "id": "05502000007B0000",
     "name": "Namco Museum [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Namco%20Museum%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Namco%20Museum.png",
     "region": "US",
     "description": "Forwarder installer for 05502000007a0000 and rom copier for roms/sdc/Namco Museum.chd"
   },
   "05502000007D0000": {
     "id": "05502000007D0000",
     "name": "Nanatsu no Hikan - Senritsu no Bishou [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Nanatsu%20no%20Hikan%20-%20Senritsu%20no%20Bishou%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Nanatsu%20no%20Hikan%20-%20Senritsu%20no%20Bishou.png",
     "region": "US",
     "description": "Forwarder installer for 05502000007c0000 and rom copier for roms/sdc/Nanatsu no Hikan - Senritsu no Bishou.chd"
   },
   "05502000007F0000": {
     "id": "05502000007F0000",
     "name": "Napple Tale - Arsia in Daydream [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Napple%20Tale%20-%20Arsia%20in%20Daydream%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Napple%20Tale%20-%20Arsia%20in%20Daydream.png",
     "region": "US",
     "description": "Forwarder installer for 05502000007e0000 and rom copier for roms/sdc/Napple Tale - Arsia in Daydream.chd"
   },
   "0550200000810000": {
     "id": "0550200000810000",
     "name": "NBA 2K [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NBA%202K%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NBA%202K.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000800000 and rom copier for roms/sdc/NBA 2K.chd"
   },
   "0550200000830000": {
     "id": "0550200000830000",
     "name": "NBA 2K1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NBA%202K1%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NBA%202K1.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000820000 and rom copier for roms/sdc/NBA 2K1.chd"
   },
   "0550200000850000": {
     "id": "0550200000850000",
     "name": "NBA 2K2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NBA%202K2%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NBA%202K2.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000840000 and rom copier for roms/sdc/NBA 2K2.chd"
   },
   "0550200000870000": {
     "id": "0550200000870000",
     "name": "NBA Hoopz [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NBA%20Hoopz%20(Europe)%20(En,Fr,De).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NBA%20Hoopz.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000860000 and rom copier for roms/sdc/NBA Hoopz.chd"
   },
   "0550200000890000": {
     "id": "0550200000890000",
     "name": "NBA Showtime - NBA on NBC [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NBA%20Showtime%20-%20NBA%20on%20NBC%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NBA%20Showtime%20-%20NBA%20on%20NBC.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000880000 and rom copier for roms/sdc/NBA Showtime - NBA on NBC.chd"
   },
   "05502000008B0000": {
     "id": "05502000008B0000",
     "name": "NCAA College Football 2K2 - Road to the Rose Bowl [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NCAA%20College%20Football%202K2%20-%20Road%20to%20the%20Rose%20Bowl%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NCAA%20College%20Football%202K2%20-%20Road%20to%20the%20Rose%20Bowl.png",
     "region": "US",
     "description": "Forwarder installer for 05502000008a0000 and rom copier for roms/sdc/NCAA College Football 2K2 - Road to the Rose Bowl.chd"
   },
   "05502000008D0000": {
     "id": "05502000008D0000",
     "name": "Neo Golden Logres [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Neo%20Golden%20Logres%20(Japan)%20(En,Ja).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Neo%20Golden%20Logres.png",
     "region": "US",
     "description": "Forwarder installer for 05502000008c0000 and rom copier for roms/sdc/Neo Golden Logres.chd"
   },
   "05502000008F0000": {
     "id": "05502000008F0000",
     "name": "Neppachi - 10-ren Chan de Las Vegas Ryokou Rev A [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Neppachi%20-%2010-ren%20Chan%20de%20Las%20Vegas%20Ryokou%20(Japan)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Neppachi%20-%2010-ren%20Chan%20de%20Las%20Vegas%20Ryokou%20Rev%20A.png",
     "region": "US",
     "description": "Forwarder installer for 05502000008e0000 and rom copier for roms/sdc/Neppachi - 10-ren Chan de Las Vegas Ryokou Rev A.chd"
   },
   "0550200000910000": {
     "id": "0550200000910000",
     "name": "Neppachi II - CR Harenchi Gakuen [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Neppachi%20II%20-%20CR%20Harenchi%20Gakuen%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Neppachi%20II%20-%20CR%20Harenchi%20Gakuen.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000900000 and rom copier for roms/sdc/Neppachi II - CR Harenchi Gakuen.chd"
   },
   "0550200000930000": {
     "id": "0550200000930000",
     "name": "Neppachi III - CR Dokonjou Gaeru 2 - CR Dokonjou Gaeru H [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Neppachi%20III%20-%20CR%20Dokonjou%20Gaeru%202%20-%20CR%20Dokonjou%20Gaeru%20H%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Neppachi%20III%20-%20CR%20Dokonjou%20Gaeru%202%20-%20CR%20Dokonjou%20Gaeru%20H.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000920000 and rom copier for roms/sdc/Neppachi III - CR Dokonjou Gaeru 2 - CR Dokonjou Gaeru H.chd"
   },
   "0550200000950000": {
     "id": "0550200000950000",
     "name": "Neppachi IV - CR Aa!! Hana no Ouendan 3 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Neppachi%20IV%20-%20CR%20Aa!!%20Hana%20no%20Ouendan%203%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Neppachi%20IV%20-%20CR%20Aa!!%20Hana%20no%20Ouendan%203.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000940000 and rom copier for roms/sdc/Neppachi IV - CR Aa!! Hana no Ouendan 3.chd"
   },
   "0550200000970000": {
     "id": "0550200000970000",
     "name": "Neppachi V - CR Monster House [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Neppachi%20V%20-%20CR%20Monster%20House%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Neppachi%20V%20-%20CR%20Monster%20House.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000960000 and rom copier for roms/sdc/Neppachi V - CR Monster House.chd"
   },
   "0550200000990000": {
     "id": "0550200000990000",
     "name": "Neppachi VI - CR Otakara Tankentai [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Neppachi%20VI%20-%20CR%20Otakara%20Tankentai%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Neppachi%20VI%20-%20CR%20Otakara%20Tankentai.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000980000 and rom copier for roms/sdc/Neppachi VI - CR Otakara Tankentai.chd"
   },
   "05502000009B0000": {
     "id": "05502000009B0000",
     "name": "Net de Para [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Net%20de%20Para%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Net%20de%20Para.png",
     "region": "US",
     "description": "Forwarder installer for 05502000009a0000 and rom copier for roms/sdc/Net de Para.chd"
   },
   "05502000009D0000": {
     "id": "05502000009D0000",
     "name": "Net de Tennis [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Net%20de%20Tennis%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Net%20de%20Tennis.png",
     "region": "US",
     "description": "Forwarder installer for 05502000009c0000 and rom copier for roms/sdc/Net de Tennis.chd"
   },
   "05502000009F0000": {
     "id": "05502000009F0000",
     "name": "Net Versus - Chess [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Net%20Versus%20-%20Chess%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Net%20Versus%20-%20Chess.png",
     "region": "US",
     "description": "Forwarder installer for 05502000009e0000 and rom copier for roms/sdc/Net Versus - Chess.chd"
   },
   "0550200000A10000": {
     "id": "0550200000A10000",
     "name": "Net Versus - Gomoku Narabe to Renju [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Net%20Versus%20-%20Gomoku%20Narabe%20to%20Renju%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Net%20Versus%20-%20Gomoku%20Narabe%20to%20Renju.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000a00000 and rom copier for roms/sdc/Net Versus - Gomoku Narabe to Renju.chd"
   },
   "0550200000A30000": {
     "id": "0550200000A30000",
     "name": "Net Versus - Hanafuda [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Net%20Versus%20-%20Hanafuda%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Net%20Versus%20-%20Hanafuda.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000a20000 and rom copier for roms/sdc/Net Versus - Hanafuda.chd"
   },
   "0550200000A50000": {
     "id": "0550200000A50000",
     "name": "Net Versus - Igo [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Net%20Versus%20-%20Igo%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Net%20Versus%20-%20Igo.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000a40000 and rom copier for roms/sdc/Net Versus - Igo.chd"
   },
   "0550200000A70000": {
     "id": "0550200000A70000",
     "name": "Net Versus - Mahjong [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Net%20Versus%20-%20Mahjong%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Net%20Versus%20-%20Mahjong.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000a60000 and rom copier for roms/sdc/Net Versus - Mahjong.chd"
   },
   "0550200000A90000": {
     "id": "0550200000A90000",
     "name": "Net Versus - Reversi [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Net%20Versus%20-%20Reversi%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Net%20Versus%20-%20Reversi.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000a80000 and rom copier for roms/sdc/Net Versus - Reversi.chd"
   },
   "0550200000AB0000": {
     "id": "0550200000AB0000",
     "name": "Net Versus - Shougi [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Net%20Versus%20-%20Shougi%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Net%20Versus%20-%20Shougi.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000aa0000 and rom copier for roms/sdc/Net Versus - Shougi.chd"
   },
   "0550200000AD0000": {
     "id": "0550200000AD0000",
     "name": "Nettou Golf [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Nettou%20Golf%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Nettou%20Golf.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000ac0000 and rom copier for roms/sdc/Nettou Golf.chd"
   },
   "0550200000AF0000": {
     "id": "0550200000AF0000",
     "name": "Never 7 - The End of Infinity [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Never%207%20-%20The%20End%20of%20Infinity%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Never%207%20-%20The%20End%20of%20Infinity.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000ae0000 and rom copier for roms/sdc/Never 7 - The End of Infinity.chd"
   },
   "0550200000B10000": {
     "id": "0550200000B10000",
     "name": "NFL 2K [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NFL%202K%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NFL%202K.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000b00000 and rom copier for roms/sdc/NFL 2K.chd"
   },
   "0550200000B30000": {
     "id": "0550200000B30000",
     "name": "NFL 2K1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NFL%202K1%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NFL%202K1.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000b20000 and rom copier for roms/sdc/NFL 2K1.chd"
   },
   "0550200000B50000": {
     "id": "0550200000B50000",
     "name": "NFL Blitz 2000 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NFL%20Blitz%202000%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NFL%20Blitz%202000.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000b40000 and rom copier for roms/sdc/NFL Blitz 2000.chd"
   },
   "0550200000B70000": {
     "id": "0550200000B70000",
     "name": "NFL Blitz 2001 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NFL%20Blitz%202001%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NFL%20Blitz%202001.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000b60000 and rom copier for roms/sdc/NFL Blitz 2001.chd"
   },
   "0550200000B90000": {
     "id": "0550200000B90000",
     "name": "NFL QB Club 2001 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NFL%20QB%20Club%202001%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NFL%20QB%20Club%202001.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000b80000 and rom copier for roms/sdc/NFL QB Club 2001.chd"
   },
   "0550200000BB0000": {
     "id": "0550200000BB0000",
     "name": "NFL Quarterback Club 2000 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NFL%20Quarterback%20Club%202000%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NFL%20Quarterback%20Club%202000.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000ba0000 and rom copier for roms/sdc/NFL Quarterback Club 2000.chd"
   },
   "0550200000BD0000": {
     "id": "0550200000BD0000",
     "name": "NHL 2K [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NHL%202K%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NHL%202K.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000bc0000 and rom copier for roms/sdc/NHL 2K.chd"
   },
   "0550200000BF0000": {
     "id": "0550200000BF0000",
     "name": "NHL 2K2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NHL%202K2%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/NHL%202K2.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000be0000 and rom copier for roms/sdc/NHL 2K2.chd"
   },
   "0550200000C10000": {
     "id": "0550200000C10000",
     "name": "Nightmare Creatures II [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Nightmare%20Creatures%20II%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Nightmare%20Creatures%20II.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000c00000 and rom copier for roms/sdc/Nightmare Creatures II.chd"
   },
   "0550200000C30000": {
     "id": "0550200000C30000",
     "name": "Nihon Pro Mahjong Renmei Kounin - Tetsuman Menkyokaiden [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Nihon%20Pro%20Mahjong%20Renmei%20Kounin%20-%20Tetsuman%20Menkyokaiden%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Nihon%20Pro%20Mahjong%20Renmei%20Kounin%20-%20Tetsuman%20Menkyokaiden.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000c20000 and rom copier for roms/sdc/Nihon Pro Mahjong Renmei Kounin - Tetsuman Menkyokaiden.chd"
   },
   "0550200000C50000": {
     "id": "0550200000C50000",
     "name": "Nijuuei [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Nijuuei%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Nijuuei.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000c40000 and rom copier for roms/sdc/Nijuuei.chd"
   },
   "0550200000C70000": {
     "id": "0550200000C70000",
     "name": "Nishikaze no Kyoushikyoku - The Rhapsody of Zephyr [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Nishikaze%20no%20Kyoushikyoku%20-%20The%20Rhapsody%20of%20Zephyr%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Nishikaze%20no%20Kyoushikyoku%20-%20The%20Rhapsody%20of%20Zephyr.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000c60000 and rom copier for roms/sdc/Nishikaze no Kyoushikyoku - The Rhapsody of Zephyr.chd"
   },
   "0550200000C90000": {
     "id": "0550200000C90000",
     "name": "Nobunaga no Yabou - Reppuuden [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Nobunaga%20no%20Yabou%20-%20Reppuuden%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Nobunaga%20no%20Yabou%20-%20Reppuuden.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000c80000 and rom copier for roms/sdc/Nobunaga no Yabou - Reppuuden.chd"
   },
   "0550200000CB0000": {
     "id": "0550200000CB0000",
     "name": "Nobunaga no Yabou - Shouseiroku with Power-Up Kit [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Nobunaga%20no%20Yabou%20-%20Shouseiroku%20with%20Power-Up%20Kit%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Nobunaga%20no%20Yabou%20-%20Shouseiroku%20with%20Power-Up%20Kit.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000ca0000 and rom copier for roms/sdc/Nobunaga no Yabou - Shouseiroku with Power-Up Kit.chd"
   },
   "0550200000CD0000": {
     "id": "0550200000CD0000",
     "name": "O-to-i-re - Dreamcast Sequencer [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Alice%20Dreams%20Tournament%20(USA)%20(Disc%201)%20(Unl).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/O-to-i-re%20-%20Dreamcast%20Sequencer.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000cc0000 and rom copier for roms/sdc/O-to-i-re - Dreamcast Sequencer.chd"
   },
   "0550200000CF0000": {
     "id": "0550200000CF0000",
     "name": "Official Sega Dreamcast Magazine Vol. 10 - January 2001 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Official%20Sega%20Dreamcast%20Magazine%20Vol.%2010%20-%20January%202001%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Official%20Sega%20Dreamcast%20Magazine%20Vol.%2010%20-%20January%202001.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000ce0000 and rom copier for roms/sdc/Official Sega Dreamcast Magazine Vol. 10 - January 2001.chd"
   },
   "0550200000D10000": {
     "id": "0550200000D10000",
     "name": "Official Sega Dreamcast Magazine Vol. 11 - February 2001 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Official%20Sega%20Dreamcast%20Magazine%20Vol.%2010%20-%20January%202001%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Official%20Sega%20Dreamcast%20Magazine%20Vol.%2010%20-%20January%202001.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000d00000 and rom copier for roms/sdc/Official Sega Dreamcast Magazine Vol. 11 - February 2001.chd"
   },
   "0550200000D30000": {
     "id": "0550200000D30000",
     "name": "Official Sega Dreamcast Magazine Vol. 2 - November 1999 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Official%20Sega%20Dreamcast%20Magazine%20Vol.%202%20-%20November%201999%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Official%20Sega%20Dreamcast%20Magazine%20Vol.%202%20-%20November%201999.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000d20000 and rom copier for roms/sdc/Official Sega Dreamcast Magazine Vol. 2 - November 1999.chd"
   },
   "0550200000D50000": {
     "id": "0550200000D50000",
     "name": "Official Sega Dreamcast Magazine Vol. 3 - January 2000 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Official%20Sega%20Dreamcast%20Magazine%20Vol.%203%20-%20January%202000%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Official%20Sega%20Dreamcast%20Magazine%20Vol.%203%20-%20January%202000.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000d40000 and rom copier for roms/sdc/Official Sega Dreamcast Magazine Vol. 3 - January 2000.chd"
   },
   "0550200000D70000": {
     "id": "0550200000D70000",
     "name": "Official Sega Dreamcast Magazine Vol. 4 - March 2000 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Official%20Sega%20Dreamcast%20Magazine%20Vol.%204%20-%20March%202000%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Official%20Sega%20Dreamcast%20Magazine%20Vol.%204%20-%20March%202000.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000d60000 and rom copier for roms/sdc/Official Sega Dreamcast Magazine Vol. 4 - March 2000.chd"
   },
   "0550200000D90000": {
     "id": "0550200000D90000",
     "name": "Official Sega Dreamcast Magazine Vol. 5 - May 2000 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Official%20Sega%20Dreamcast%20Magazine%20Vol.%204%20-%20March%202000%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Official%20Sega%20Dreamcast%20Magazine%20Vol.%204%20-%20March%202000.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000d80000 and rom copier for roms/sdc/Official Sega Dreamcast Magazine Vol. 5 - May 2000.chd"
   },
   "0550200000DB0000": {
     "id": "0550200000DB0000",
     "name": "Official Sega Dreamcast Magazine Vol. 6 - July 2000 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Official%20Sega%20Dreamcast%20Magazine%20Vol.%206%20-%20July%202000%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Official%20Sega%20Dreamcast%20Magazine%20Vol.%206%20-%20July%202000.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000da0000 and rom copier for roms/sdc/Official Sega Dreamcast Magazine Vol. 6 - July 2000.chd"
   },
   "0550200000DD0000": {
     "id": "0550200000DD0000",
     "name": "Official Sega Dreamcast Magazine Vol. 7 - September 2000 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Official%20Sega%20Dreamcast%20Magazine%20Vol.%207%20-%20September%202000%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Official%20Sega%20Dreamcast%20Magazine%20Vol.%207%20-%20September%202000.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000dc0000 and rom copier for roms/sdc/Official Sega Dreamcast Magazine Vol. 7 - September 2000.chd"
   },
   "0550200000DF0000": {
     "id": "0550200000DF0000",
     "name": "Official Sega Dreamcast Magazine Vol. 8 - November 2000 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Official%20Sega%20Dreamcast%20Magazine%20Vol.%208%20-%20November%202000%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Official%20Sega%20Dreamcast%20Magazine%20Vol.%208%20-%20November%202000.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000de0000 and rom copier for roms/sdc/Official Sega Dreamcast Magazine Vol. 8 - November 2000.chd"
   },
   "0550200000E10000": {
     "id": "0550200000E10000",
     "name": "Official Sega Dreamcast Magazine Vol. 9 - December 2000 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Official%20Sega%20Dreamcast%20Magazine%20Vol.%209%20-%20December%202000%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Official%20Sega%20Dreamcast%20Magazine%20Vol.%209%20-%20December%202000.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000e00000 and rom copier for roms/sdc/Official Sega Dreamcast Magazine Vol. 9 - December 2000.chd"
   },
   "0550200000E30000": {
     "id": "0550200000E30000",
     "name": "Omikron - The Nomad Soul [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Omikron%20-%20The%20Nomad%20Soul%20(USA)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Omikron%20-%20The%20Nomad%20Soul.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000e20000 and rom copier for roms/sdc/Omikron - The Nomad Soul.chd"
   },
   "0550200000E50000": {
     "id": "0550200000E50000",
     "name": "Omoide ni Kawaru Kimi - Memories Off [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Omoide%20ni%20Kawaru%20Kimi%20-%20Memories%20Off%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Omoide%20ni%20Kawaru%20Kimi%20-%20Memories%20Off.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000e40000 and rom copier for roms/sdc/Omoide ni Kawaru Kimi - Memories Off.chd"
   },
   "0550200000E70000": {
     "id": "0550200000E70000",
     "name": "Ooga Booga [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ooga%20Booga%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ooga%20Booga.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000e60000 and rom copier for roms/sdc/Ooga Booga.chd"
   },
   "0550200000E90000": {
     "id": "0550200000E90000",
     "name": "Oogami Ichirou Funtou-ki - Sakura Taisen Kayou Show Beni Tokage yori Disc #1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Oogami%20Ichirou%20Funtou-ki%20-%20Sakura%20Taisen%20Kayou%20Show%20Beni%20Tokage%20yori%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Oogami%20Ichirou%20Funtou-ki%20-%20Sakura%20Taisen%20Kayou%20Show%20Beni%20Tokage%20yori%20Disc%20%231.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000e80000 and rom copier for roms/sdc/Oogami Ichirou Funtou-ki - Sakura Taisen Kayou Show Beni Tokage yori Disc #1.chd"
   },
   "0550200000EB0000": {
     "id": "0550200000EB0000",
     "name": "Oogami Ichirou Funtou-ki - Sakura Taisen Kayou Show Beni Tokage yori Disc #2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Oogami%20Ichirou%20Funtou-ki%20-%20Sakura%20Taisen%20Kayou%20Show%20Beni%20Tokage%20yori%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Oogami%20Ichirou%20Funtou-ki%20-%20Sakura%20Taisen%20Kayou%20Show%20Beni%20Tokage%20yori%20Disc%20%232.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000ea0000 and rom copier for roms/sdc/Oogami Ichirou Funtou-ki - Sakura Taisen Kayou Show Beni Tokage yori Disc #2.chd"
   },
   "0550200000ED0000": {
     "id": "0550200000ED0000",
     "name": "Orange Pocket - Cornet [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Surf%20Rocket%20Racers%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Surf%20Rocket%20Racers.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000ec0000 and rom copier for roms/sdc/Orange Pocket - Cornet.chd"
   },
   "0550200000EF0000": {
     "id": "0550200000EF0000",
     "name": "Ouka Houshin - Ouka Saki shi Toki [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ouka%20Houshin%20-%20Ouka%20Saki%20shi%20Toki%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ouka%20Houshin%20-%20Ouka%20Saki%20shi%20Toki.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000ee0000 and rom copier for roms/sdc/Ouka Houshin - Ouka Saki shi Toki.chd"
   },
   "0550200000F10000": {
     "id": "0550200000F10000",
     "name": "Outtrigger [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Outtrigger%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Outtrigger.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000f00000 and rom copier for roms/sdc/Outtrigger.chd"
   },
   "0550200000F30000": {
     "id": "0550200000F30000",
     "name": "Pachi-Slot Teiou - Dream Slot - Heiwa SP [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pachi-Slot%20Teiou%20-%20Dream%20Slot%20-%20Heiwa%20SP%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pachi-Slot%20Teiou%20-%20Dream%20Slot%20-%20Heiwa%20SP.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000f20000 and rom copier for roms/sdc/Pachi-Slot Teiou - Dream Slot - Heiwa SP.chd"
   },
   "0550200000F50000": {
     "id": "0550200000F50000",
     "name": "Pachi-Slot Teiou - Dream Slot - Olympia SP [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pachi-Slot%20Teiou%20-%20Dream%20Slot%20-%20Olympia%20SP%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pachi-Slot%20Teiou%20-%20Dream%20Slot%20-%20Olympia%20SP.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000f40000 and rom copier for roms/sdc/Pachi-Slot Teiou - Dream Slot - Olympia SP.chd"
   },
   "0550200000F70000": {
     "id": "0550200000F70000",
     "name": "Pachinko no Dendou - CR Nanasy [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pachinko%20no%20Dendou%20-%20CR%20Nanasy%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pachinko%20no%20Dendou%20-%20CR%20Nanasy.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000f60000 and rom copier for roms/sdc/Pachinko no Dendou - CR Nanasy.chd"
   },
   "0550200000F90000": {
     "id": "0550200000F90000",
     "name": "Pandora no Yume [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pandora%20no%20Yume%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pandora%20no%20Yume.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000f80000 and rom copier for roms/sdc/Pandora no Yume.chd"
   },
   "0550200000FB0000": {
     "id": "0550200000FB0000",
     "name": "Panzer Front [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Panzer%20Front%20(Japan)%20(En,Ja).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Panzer%20Front.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000fa0000 and rom copier for roms/sdc/Panzer Front.chd"
   },
   "0550200000FD0000": {
     "id": "0550200000FD0000",
     "name": "Patissier na Nyanko - Hatsukoi wa Ichigo Aji [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Castle%20Fantasia%20-%20Seima%20Taisen%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Castle%20Fantasia%20-%20Seima%20Taisen.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000fc0000 and rom copier for roms/sdc/Patissier na Nyanko - Hatsukoi wa Ichigo Aji.chd"
   },
   "0550200000FF0000": {
     "id": "0550200000FF0000",
     "name": "PenPen TriIcelon [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/PenPen%20TriIcelon%20(Japan)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/PenPen%20TriIcelon.png",
     "region": "US",
     "description": "Forwarder installer for 0550200000fe0000 and rom copier for roms/sdc/PenPen TriIcelon.chd"
   },
   "0550200001010000": {
     "id": "0550200001010000",
     "name": "PenPen [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/PenPen%20(Europe)%20(En,Fr,De,Es,It,Nl).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/PenPen.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001000000 and rom copier for roms/sdc/PenPen.chd"
   },
   "0550200001030000": {
     "id": "0550200001030000",
     "name": "Phantasy Star Online Ver. 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Phantasy%20Star%20Online%20Ver.%202%20(Europe)%20(En,Ja,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Phantasy%20Star%20Online%20Ver.%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001020000 and rom copier for roms/sdc/Phantasy Star Online Ver. 2.chd"
   },
   "0550200001050000": {
     "id": "0550200001050000",
     "name": "Pia Carrot e Youkoso!! 2.5 - Disc 1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pia%20Carrot%20e%20Youkoso!!%202.5%20(Japan)%20(Disc%201)%20(Pia%20Carrot%20e%20Youkoso!!%202).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pia%20Carrot%20e%20Youkoso!!%202.5%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001040000 and rom copier for roms/sdc/Pia Carrot e Youkoso!! 2.5 - Disc 1.chd"
   },
   "0550200001070000": {
     "id": "0550200001070000",
     "name": "Pia Carrot e Youkoso!! 2.5 - Disc 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pia%20Carrot%20e%20Youkoso!!%202.5%20(Japan)%20(Disc%201)%20(Pia%20Carrot%20e%20Youkoso!!%202).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pia%20Carrot%20e%20Youkoso!!%202.5%20-%20Disc%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001060000 and rom copier for roms/sdc/Pia Carrot e Youkoso!! 2.5 - Disc 2.chd"
   },
   "0550200001090000": {
     "id": "0550200001090000",
     "name": "Pia Carrot e Youkoso!! 3 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pia%20Carrot%20e%20Youkoso!!%203%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pia%20Carrot%20e%20Youkoso!!%203.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001080000 and rom copier for roms/sdc/Pia Carrot e Youkoso!! 3.chd"
   },
   "05502000010B0000": {
     "id": "05502000010B0000",
     "name": "Pizzicato Polka - Ensa Gen'ya [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pizzicato%20Polka%20-%20Ensa%20Gen'ya%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pizzicato%20Polka%20-%20Ensa%20Gen'ya.png",
     "region": "US",
     "description": "Forwarder installer for 05502000010a0000 and rom copier for roms/sdc/Pizzicato Polka - Ensa Gen'ya.chd"
   },
   "05502000010D0000": {
     "id": "05502000010D0000",
     "name": "Planet Ring [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Planet%20Ring%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Planet%20Ring.png",
     "region": "US",
     "description": "Forwarder installer for 05502000010c0000 and rom copier for roms/sdc/Planet Ring.chd"
   },
   "05502000010F0000": {
     "id": "05502000010F0000",
     "name": "Plasma Sword - Nightmare of Bilstein [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Plasma%20Sword%20-%20Nightmare%20of%20Bilstein%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Plasma%20Sword%20-%20Nightmare%20of%20Bilstein.png",
     "region": "US",
     "description": "Forwarder installer for 05502000010e0000 and rom copier for roms/sdc/Plasma Sword - Nightmare of Bilstein.chd"
   },
   "0550200001110000": {
     "id": "0550200001110000",
     "name": "Plus Plumb [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Plus%20Plumb%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Plus%20Plumb.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001100000 and rom copier for roms/sdc/Plus Plumb.chd"
   },
   "0550200001130000": {
     "id": "0550200001130000",
     "name": "Pocke-Kano - Yumi - Shizuka - Fumio [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pocke-Kano%20-%20Yumi,%20Shizuka,%20Fumio%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pocke-Kano%20-%20Yumi%20-%20Shizuka%20-%20Fumio.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001120000 and rom copier for roms/sdc/Pocke-Kano - Yumi - Shizuka - Fumio.chd"
   },
   "0550200001150000": {
     "id": "0550200001150000",
     "name": "POD - Speedzone [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/POD%20-%20Speedzone%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/POD%20-%20Speedzone.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001140000 and rom copier for roms/sdc/POD - Speedzone.chd"
   },
   "0550200001170000": {
     "id": "0550200001170000",
     "name": "POD 2 - Multiplayer Online [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/POD%202%20-%20Multiplayer%20Online%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/POD%202%20-%20Multiplayer%20Online.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001160000 and rom copier for roms/sdc/POD 2 - Multiplayer Online.chd"
   },
   "0550200001190000": {
     "id": "0550200001190000",
     "name": "Pop'n Music 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pop'n%20Music%202%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pop'n%20Music%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001180000 and rom copier for roms/sdc/Pop'n Music 2.chd"
   },
   "05502000011B0000": {
     "id": "05502000011B0000",
     "name": "Pop'n Music 3 - Append Disc [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pop'n%20Music%203%20-%20Append%20Disc%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pop'n%20Music%203%20-%20Append%20Disc.png",
     "region": "US",
     "description": "Forwarder installer for 05502000011a0000 and rom copier for roms/sdc/Pop'n Music 3 - Append Disc.chd"
   },
   "05502000011D0000": {
     "id": "05502000011D0000",
     "name": "Pop'n Music 4 - Append Disc [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pop'n%20Music%204%20-%20Append%20Disc%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pop'n%20Music%204%20-%20Append%20Disc.png",
     "region": "US",
     "description": "Forwarder installer for 05502000011c0000 and rom copier for roms/sdc/Pop'n Music 4 - Append Disc.chd"
   },
   "05502000011F0000": {
     "id": "05502000011F0000",
     "name": "Pop'n Music [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pop'n%20Music%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pop'n%20Music.png",
     "region": "US",
     "description": "Forwarder installer for 05502000011e0000 and rom copier for roms/sdc/Pop'n Music.chd"
   },
   "0550200001210000": {
     "id": "0550200001210000",
     "name": "Power Jet Racing 2001 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Power%20Jet%20Racing%202001%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Power%20Jet%20Racing%202001.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001200000 and rom copier for roms/sdc/Power Jet Racing 2001.chd"
   },
   "0550200001230000": {
     "id": "0550200001230000",
     "name": "Power Smash - Sega Professional Tennis [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Power%20Smash%20-%20Sega%20Professional%20Tennis%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Power%20Smash%20-%20Sega%20Professional%20Tennis.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001220000 and rom copier for roms/sdc/Power Smash - Sega Professional Tennis.chd"
   },
   "0550200001250000": {
     "id": "0550200001250000",
     "name": "Power Smash 2 - Sega Professional Tennis [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Power%20Smash%202%20-%20Sega%20Professional%20Tennis%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Power%20Smash%202%20-%20Sega%20Professional%20Tennis.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001240000 and rom copier for roms/sdc/Power Smash 2 - Sega Professional Tennis.chd"
   },
   "0550200001270000": {
     "id": "0550200001270000",
     "name": "Power Stone 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Power%20Stone%202%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Power%20Stone%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001260000 and rom copier for roms/sdc/Power Stone 2.chd"
   },
   "0550200001290000": {
     "id": "0550200001290000",
     "name": "Power Stone [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Power%20Stone%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Power%20Stone.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001280000 and rom copier for roms/sdc/Power Stone.chd"
   },
   "05502000012B0000": {
     "id": "05502000012B0000",
     "name": "Prince of Persia - Arabian Nights [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Prince%20of%20Persia%20-%20Arabian%20Nights%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Prince%20of%20Persia%20-%20Arabian%20Nights.png",
     "region": "US",
     "description": "Forwarder installer for 05502000012a0000 and rom copier for roms/sdc/Prince of Persia - Arabian Nights.chd"
   },
   "05502000012D0000": {
     "id": "05502000012D0000",
     "name": "Princess Holiday - Korogaru Ringo Tei Sen'ya Ichiya [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Princess%20Holiday%20-%20Korogaru%20Ringo%20Tei%20Sen'ya%20Ichiya%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Princess%20Holiday%20-%20Korogaru%20Ringo%20Tei%20Sen'ya%20Ichiya.png",
     "region": "US",
     "description": "Forwarder installer for 05502000012c0000 and rom copier for roms/sdc/Princess Holiday - Korogaru Ringo Tei Sen'ya Ichiya.chd"
   },
   "05502000012F0000": {
     "id": "05502000012F0000",
     "name": "Princess Maker Collection [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Princess%20Maker%20Collection%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Princess%20Maker%20Collection.png",
     "region": "US",
     "description": "Forwarder installer for 05502000012e0000 and rom copier for roms/sdc/Princess Maker Collection.chd"
   },
   "0550200001310000": {
     "id": "0550200001310000",
     "name": "Prism Heart - Gaiden Disc - Ken ni Kometa Omoi [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Prism%20Heart%20-%20Gaiden%20Disc%20-%20Ken%20ni%20Kometa%20Omoi%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Prism%20Heart%20-%20Gaiden%20Disc%20-%20Ken%20ni%20Kometa%20Omoi.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001300000 and rom copier for roms/sdc/Prism Heart - Gaiden Disc - Ken ni Kometa Omoi.chd"
   },
   "0550200001330000": {
     "id": "0550200001330000",
     "name": "Prism Heart [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Prism%20Heart%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Prism%20Heart.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001320000 and rom copier for roms/sdc/Prism Heart.chd"
   },
   "0550200001350000": {
     "id": "0550200001350000",
     "name": "Prismaticallization [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Prismaticallization%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Prismaticallization.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001340000 and rom copier for roms/sdc/Prismaticallization.chd"
   },
   "0550200001370000": {
     "id": "0550200001370000",
     "name": "Pro Mahjong Kiwame D [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pro%20Mahjong%20Kiwame%20D%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pro%20Mahjong%20Kiwame%20D.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001360000 and rom copier for roms/sdc/Pro Mahjong Kiwame D.chd"
   },
   "0550200001390000": {
     "id": "0550200001390000",
     "name": "Pro Pinball Trilogy [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pro%20Pinball%20Trilogy%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pro%20Pinball%20Trilogy.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001380000 and rom copier for roms/sdc/Pro Pinball Trilogy.chd"
   },
   "05502000013B0000": {
     "id": "05502000013B0000",
     "name": "Pro Yakyuu Team de Asobou! [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pro%20Yakyuu%20Team%20de%20Asobou!%20(Japan)%20(Tokubetsuban).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pro%20Yakyuu%20Team%20de%20Asobou!.png",
     "region": "US",
     "description": "Forwarder installer for 05502000013a0000 and rom copier for roms/sdc/Pro Yakyuu Team de Asobou!.chd"
   },
   "05502000013D0000": {
     "id": "05502000013D0000",
     "name": "Pro Yakyuu Team o Tsukurou! & Asobou! [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pro%20Yakyuu%20Team%20o%20Tsukurou!%20_%20Asobou!%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pro%20Yakyuu%20Team%20o%20Tsukurou!%20%26%20Asobou!.png",
     "region": "US",
     "description": "Forwarder installer for 05502000013c0000 and rom copier for roms/sdc/Pro Yakyuu Team o Tsukurou! & Asobou!.chd"
   },
   "05502000013F0000": {
     "id": "05502000013F0000",
     "name": "Pro Yakyuu Team o Tsukurou! [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pro%20Yakyuu%20Team%20o%20Tsukurou!%20(Japan)%20(Rev%20B).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Pro%20Yakyuu%20Team%20o%20Tsukurou!.png",
     "region": "US",
     "description": "Forwarder installer for 05502000013e0000 and rom copier for roms/sdc/Pro Yakyuu Team o Tsukurou!.chd"
   },
   "0550200001410000": {
     "id": "0550200001410000",
     "name": "Project Berkley [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Project%20Berkley%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Project%20Berkley.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001400000 and rom copier for roms/sdc/Project Berkley.chd"
   },
   "0550200001430000": {
     "id": "0550200001430000",
     "name": "Project Justice - Rival Schools 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Project%20Justice%20-%20Rival%20Schools%202%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Project%20Justice%20-%20Rival%20Schools%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001420000 and rom copier for roms/sdc/Project Justice - Rival Schools 2.chd"
   },
   "0550200001450000": {
     "id": "0550200001450000",
     "name": "Project Justice [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Project%20Justice%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Project%20Justice.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001440000 and rom copier for roms/sdc/Project Justice.chd"
   },
   "0550200001470000": {
     "id": "0550200001470000",
     "name": "Psychic Force 2012 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Psychic%20Force%202012%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Psychic%20Force%202012.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001460000 and rom copier for roms/sdc/Psychic Force 2012.chd"
   },
   "0550200001490000": {
     "id": "0550200001490000",
     "name": "Psyvariar 2 - The Will to Fabricate [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Psyvariar%202%20-%20The%20Will%20to%20Fabricate%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Psyvariar%202%20-%20The%20Will%20to%20Fabricate.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001480000 and rom copier for roms/sdc/Psyvariar 2 - The Will to Fabricate.chd"
   },
   "05502000014B0000": {
     "id": "05502000014B0000",
     "name": "Puyo Puyo Da! Featuring Ellena System [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Puyo%20Puyo%20Da!%20Featuring%20Ellena%20System%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Puyo%20Puyo%20Da!%20Featuring%20Ellena%20System.png",
     "region": "US",
     "description": "Forwarder installer for 05502000014a0000 and rom copier for roms/sdc/Puyo Puyo Da! Featuring Ellena System.chd"
   },
   "05502000014D0000": {
     "id": "05502000014D0000",
     "name": "Puyo Puyo Fever [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Puyo%20Puyo%20Fever%20(Japan)%20(En,Ja).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Puyo%20Puyo%20Fever.png",
     "region": "US",
     "description": "Forwarder installer for 05502000014c0000 and rom copier for roms/sdc/Puyo Puyo Fever.chd"
   },
   "05502000014F0000": {
     "id": "05502000014F0000",
     "name": "Puyo Puyoon [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Puyo%20Puyoon%20(Japan)%20(Taikenban).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Puyo%20Puyoon.png",
     "region": "US",
     "description": "Forwarder installer for 05502000014e0000 and rom copier for roms/sdc/Puyo Puyoon.chd"
   },
   "0550200001510000": {
     "id": "0550200001510000",
     "name": "Puzzle Bobble 4 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Puzzle%20Bobble%204%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Puzzle%20Bobble%204.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001500000 and rom copier for roms/sdc/Puzzle Bobble 4.chd"
   },
   "0550200001530000": {
     "id": "0550200001530000",
     "name": "Q-bert [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Q-bert%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Q-bert.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001520000 and rom copier for roms/sdc/Q-bert.chd"
   },
   "0550200001550000": {
     "id": "0550200001550000",
     "name": "Quake III - Arena [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Quake%20III%20-%20Arena%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Quake%20III%20-%20Arena.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001540000 and rom copier for roms/sdc/Quake III - Arena.chd"
   },
   "0550200001570000": {
     "id": "0550200001570000",
     "name": "Quiz Aa Megami-sama - Tatakau Tsubasa to Tomoni [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Quiz%20Aa%20Megami-sama%20-%20Tatakau%20Tsubasa%20to%20Tomoni%20(Japan)%20(Tokubetsu%20Omake%20GD-ROM).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Quiz%20Aa%20Megami-sama%20-%20Tatakau%20Tsubasa%20to%20Tomoni.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001560000 and rom copier for roms/sdc/Quiz Aa Megami-sama - Tatakau Tsubasa to Tomoni.chd"
   },
   "0550200001590000": {
     "id": "0550200001590000",
     "name": "R7 - Regulation 7 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jet%20Set%20Radio%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jet%20Set%20Radio.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001580000 and rom copier for roms/sdc/R7 - Regulation 7.chd"
   },
   "05502000015B0000": {
     "id": "05502000015B0000",
     "name": "Racing Simulation - Monaco Grand Prix [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Racing%20Simulation%20-%20Monaco%20Grand%20Prix%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Racing%20Simulation%20-%20Monaco%20Grand%20Prix.png",
     "region": "US",
     "description": "Forwarder installer for 05502000015a0000 and rom copier for roms/sdc/Racing Simulation - Monaco Grand Prix.chd"
   },
   "05502000015D0000": {
     "id": "05502000015D0000",
     "name": "Racing Simulation 2 - Monaco Grand Prix On-Line [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Racing%20Simulation%202%20-%20Monaco%20Grand%20Prix%20On-Line%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Racing%20Simulation%202%20-%20Monaco%20Grand%20Prix%20On-Line.png",
     "region": "US",
     "description": "Forwarder installer for 05502000015c0000 and rom copier for roms/sdc/Racing Simulation 2 - Monaco Grand Prix On-Line.chd"
   },
   "05502000015F0000": {
     "id": "05502000015F0000",
     "name": "Radirgy [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Radirgy%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Radirgy.png",
     "region": "US",
     "description": "Forwarder installer for 05502000015e0000 and rom copier for roms/sdc/Radirgy.chd"
   },
   "0550200001610000": {
     "id": "0550200001610000",
     "name": "Railroad Tycoon II [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Railroad%20Tycoon%20II%20(Europe)%20(En,Fr,De).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Railroad%20Tycoon%20II.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001600000 and rom copier for roms/sdc/Railroad Tycoon II.chd"
   },
   "0550200001630000": {
     "id": "0550200001630000",
     "name": "Rainbow Cotton [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Rainbow%20Cotton%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Rainbow%20Cotton.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001620000 and rom copier for roms/sdc/Rainbow Cotton.chd"
   },
   "0550200001650000": {
     "id": "0550200001650000",
     "name": "Rayman - Kaizokusen kara no Dasshutsu! [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Rayman%20-%20Kaizokusen%20kara%20no%20Dasshutsu!%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Rayman%20-%20Kaizokusen%20kara%20no%20Dasshutsu!.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001640000 and rom copier for roms/sdc/Rayman - Kaizokusen kara no Dasshutsu!.chd"
   },
   "0550200001670000": {
     "id": "0550200001670000",
     "name": "Rayman 2 - The Great Escape [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Rayman%202%20-%20The%20Great%20Escape%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Rayman%202%20-%20The%20Great%20Escape.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001660000 and rom copier for roms/sdc/Rayman 2 - The Great Escape.chd"
   },
   "0550200001690000": {
     "id": "0550200001690000",
     "name": "Razor Freestyle Scooter [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Razor%20Freestyle%20Scooter%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Razor%20Freestyle%20Scooter.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001680000 and rom copier for roms/sdc/Razor Freestyle Scooter.chd"
   },
   "05502000016B0000": {
     "id": "05502000016B0000",
     "name": "Re-Volt [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Re-Volt%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Re-Volt.png",
     "region": "US",
     "description": "Forwarder installer for 05502000016a0000 and rom copier for roms/sdc/Re-Volt.chd"
   },
   "05502000016D0000": {
     "id": "05502000016D0000",
     "name": "Ready 2 Rumble Boxing - Round 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ready%202%20Rumble%20Boxing%20-%20Round%202%20(Europe)%20(En,Fr,De).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ready%202%20Rumble%20Boxing%20-%20Round%202.png",
     "region": "US",
     "description": "Forwarder installer for 05502000016c0000 and rom copier for roms/sdc/Ready 2 Rumble Boxing - Round 2.chd"
   },
   "05502000016F0000": {
     "id": "05502000016F0000",
     "name": "Ready 2 Rumble Boxing - Uchikome Warai no Megaton Punch!! [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ready%202%20Rumble%20Boxing%20-%20Uchikome%20Warai%20no%20Megaton%20Punch!!%20(Japan)%20(En,Ja,Fr,De).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ready%202%20Rumble%20Boxing%20-%20Uchikome%20Warai%20no%20Megaton%20Punch!!.png",
     "region": "US",
     "description": "Forwarder installer for 05502000016e0000 and rom copier for roms/sdc/Ready 2 Rumble Boxing - Uchikome Warai no Megaton Punch!!.chd"
   },
   "0550200001710000": {
     "id": "0550200001710000",
     "name": "Ready 2 Rumble Boxing [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ready%202%20Rumble%20Boxing%20(Europe)%20(En,Fr,De).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ready%202%20Rumble%20Boxing.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001700000 and rom copier for roms/sdc/Ready 2 Rumble Boxing.chd"
   },
   "0550200001730000": {
     "id": "0550200001730000",
     "name": "Real Sound - Kaze no Regret - Disc 1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Real%20Sound%20-%20Kaze%20no%20Regret%20(Japan)%20(Disc%201)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Real%20Sound%20-%20Kaze%20no%20Regret%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001720000 and rom copier for roms/sdc/Real Sound - Kaze no Regret - Disc 1.chd"
   },
   "0550200001750000": {
     "id": "0550200001750000",
     "name": "Real Sound - Kaze no Regret - Disc 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Real%20Sound%20-%20Kaze%20no%20Regret%20(Japan)%20(Disc%201)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Real%20Sound%20-%20Kaze%20no%20Regret%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001740000 and rom copier for roms/sdc/Real Sound - Kaze no Regret - Disc 2.chd"
   },
   "0550200001770000": {
     "id": "0550200001770000",
     "name": "Record of Lodoss War - The Advent of Cardice [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Record%20of%20Lodoss%20War%20-%20The%20Advent%20of%20Cardice%20(Japan)%20(Taikenban).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Record%20of%20Lodoss%20War%20-%20The%20Advent%20of%20Cardice.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001760000 and rom copier for roms/sdc/Record of Lodoss War - The Advent of Cardice.chd"
   },
   "0550200001790000": {
     "id": "0550200001790000",
     "name": "Record of Lodoss War [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Record%20of%20Lodoss%20War%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Record%20of%20Lodoss%20War.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001780000 and rom copier for roms/sdc/Record of Lodoss War.chd"
   },
   "05502000017B0000": {
     "id": "05502000017B0000",
     "name": "Red Dog - Superior Firepower [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Red%20Dog%20-%20Superior%20Firepower%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Red%20Dog%20-%20Superior%20Firepower.png",
     "region": "US",
     "description": "Forwarder installer for 05502000017a0000 and rom copier for roms/sdc/Red Dog - Superior Firepower.chd"
   },
   "05502000017D0000": {
     "id": "05502000017D0000",
     "name": "Redline Racer [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Redline%20Racer%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Redline%20Racer.png",
     "region": "US",
     "description": "Forwarder installer for 05502000017c0000 and rom copier for roms/sdc/Redline Racer.chd"
   },
   "05502000017F0000": {
     "id": "05502000017F0000",
     "name": "Reel Fishing + Wild [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Reel%20Fishing%20+%20Wild%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Reel%20Fishing%20+%20Wild.png",
     "region": "US",
     "description": "Forwarder installer for 05502000017e0000 and rom copier for roms/sdc/Reel Fishing + Wild.chd"
   },
   "0550200001810000": {
     "id": "0550200001810000",
     "name": "Ren'ai Chu! Happy Perfect [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ren'ai%20Chu!%20Happy%20Perfect%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ren'ai%20Chu!%20Happy%20Perfect.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001800000 and rom copier for roms/sdc/Ren'ai Chu! Happy Perfect.chd"
   },
   "0550200001830000": {
     "id": "0550200001830000",
     "name": "Rent a Hero No.1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Rent%20a%20Hero%20No.1%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Rent%20a%20Hero%20No.1.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001820000 and rom copier for roms/sdc/Rent a Hero No.1.chd"
   },
   "0550200001850000": {
     "id": "0550200001850000",
     "name": "Resident Evil - Code - Veronica disc 1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Resident%20Evil%20-%20Code%20-%20Veronica%20(Europe)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Resident%20Evil%20-%20Code%20-%20Veronica%20disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001840000 and rom copier for roms/sdc/Resident Evil - Code - Veronica disc 1.chd"
   },
   "0550200001870000": {
     "id": "0550200001870000",
     "name": "Resident Evil - Code - Veronica disc 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Resident%20Evil%20-%20Code%20-%20Veronica%20(Europe)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Resident%20Evil%20-%20Code%20-%20Veronica%20disc%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001860000 and rom copier for roms/sdc/Resident Evil - Code - Veronica disc 2.chd"
   },
   "0550200001890000": {
     "id": "0550200001890000",
     "name": "Resident Evil 2 Disc 1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Resident%20Evil%202%20(Europe)%20(En,Fr)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Resident%20Evil%202%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001880000 and rom copier for roms/sdc/Resident Evil 2 Disc 1.chd"
   },
   "05502000018B0000": {
     "id": "05502000018B0000",
     "name": "Resident Evil 2 Disc 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Resident%20Evil%202%20(Europe)%20(En,Fr)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Resident%20Evil%202%20Disc%202.png",
     "region": "US",
     "description": "Forwarder installer for 05502000018a0000 and rom copier for roms/sdc/Resident Evil 2 Disc 2.chd"
   },
   "05502000018D0000": {
     "id": "05502000018D0000",
     "name": "Resident Evil 3 - Nemesis [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Resident%20Evil%203%20-%20Nemesis%20(Europe)%20(Fr,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Resident%20Evil%203%20-%20Nemesis.png",
     "region": "US",
     "description": "Forwarder installer for 05502000018c0000 and rom copier for roms/sdc/Resident Evil 3 - Nemesis.chd"
   },
   "05502000018F0000": {
     "id": "05502000018F0000",
     "name": "Revive... - Sosei [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Revive...%20-%20Sosei%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Revive...%20-%20Sosei.png",
     "region": "US",
     "description": "Forwarder installer for 05502000018e0000 and rom copier for roms/sdc/Revive... - Sosei.chd"
   },
   "0550200001910000": {
     "id": "0550200001910000",
     "name": "Rez [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Rez%20(Europe)%20(En,Ja,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Rez.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001900000 and rom copier for roms/sdc/Rez.chd"
   },
   "0550200001930000": {
     "id": "0550200001930000",
     "name": "Ring, The - Terror's Realm [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ring,%20The%20-%20Terror's%20Realm%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ring,%20The%20-%20Terror's%20Realm.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001920000 and rom copier for roms/sdc/Ring, The - Terror's Realm.chd"
   },
   "0550200001950000": {
     "id": "0550200001950000",
     "name": "Rippin' Riders [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Rippin'%20Riders%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Rippin'%20Riders.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001940000 and rom copier for roms/sdc/Rippin' Riders.chd"
   },
   "0550200001970000": {
     "id": "0550200001970000",
     "name": "Roadsters [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Roadsters%20(Europe)%20(En,Fr,De,Es,It,Nl).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Roadsters.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001960000 and rom copier for roms/sdc/Roadsters.chd"
   },
   "0550200001990000": {
     "id": "0550200001990000",
     "name": "Roommania 203 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Roommania%20203%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Roommania%20203.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001980000 and rom copier for roms/sdc/Roommania 203.chd"
   },
   "05502000019B0000": {
     "id": "05502000019B0000",
     "name": "Roommate Asami - Okusama wa Joshikousei - Director's Edition [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Roommate%20Asami%20-%20Okusama%20wa%20Joshikousei%20-%20Director's%20Edition%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Roommate%20Asami%20-%20Okusama%20wa%20Joshikousei%20-%20Director's%20Edition.png",
     "region": "US",
     "description": "Forwarder installer for 05502000019a0000 and rom copier for roms/sdc/Roommate Asami - Okusama wa Joshikousei - Director's Edition.chd"
   },
   "05502000019D0000": {
     "id": "05502000019D0000",
     "name": "Roommate Novel - Satou Yuka [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Roommate%20Novel%20-%20Satou%20Yuka%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Roommate%20Novel%20-%20Satou%20Yuka.png",
     "region": "US",
     "description": "Forwarder installer for 05502000019c0000 and rom copier for roms/sdc/Roommate Novel - Satou Yuka.chd"
   },
   "05502000019F0000": {
     "id": "05502000019F0000",
     "name": "Run=Dim as Black Soul [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Run=Dim%20as%20Black%20Soul%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Run=Dim%20as%20Black%20Soul.png",
     "region": "US",
     "description": "Forwarder installer for 05502000019e0000 and rom copier for roms/sdc/Run=Dim as Black Soul.chd"
   },
   "0550200001A10000": {
     "id": "0550200001A10000",
     "name": "Rune Caster [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Rune%20Caster%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Rune%20Caster.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001a00000 and rom copier for roms/sdc/Rune Caster.chd"
   },
   "0550200001A30000": {
     "id": "0550200001A30000",
     "name": "Rune Jade [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Rune%20Jade%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Rune%20Jade.png",
     "region": "US",
     "description": "Forwarder installer for 0550200001a20000 and rom copier for roms/sdc/Rune Jade.chd"
   },
   "0550300000010000": {
     "id": "0550300000010000",
     "name": "Saka Tsuku Tokudai-gou - J.League Pro Soccer Club o Tsukurou! [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Saka%20Tsuku%20Tokudai-gou%20-%20J.League%20Pro%20Soccer%20Club%20o%20Tsukurou!%20(Japan)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Saka%20Tsuku%20Tokudai-gou%20-%20J.League%20Pro%20Soccer%20Club%20o%20Tsukurou!.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000000000 and rom copier for roms/sdc/Saka Tsuku Tokudai-gou - J.League Pro Soccer Club o Tsukurou!.chd"
   },
   "0550300000030000": {
     "id": "0550300000030000",
     "name": "Saka Tsuku Tokudai-gou 2 - J.League Pro Soccer Club o Tsukurou! [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Saka%20Tsuku%20Tokudai-gou%202%20-%20J.League%20Pro%20Soccer%20Club%20o%20Tsukurou!%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Saka%20Tsuku%20Tokudai-gou%202%20-%20J.League%20Pro%20Soccer%20Club%20o%20Tsukurou!.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000020000 and rom copier for roms/sdc/Saka Tsuku Tokudai-gou 2 - J.League Pro Soccer Club o Tsukurou!.chd"
   },
   "0550300000050000": {
     "id": "0550300000050000",
     "name": "Sakura Momoko Gekijou - Coji-Coji [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Momoko%20Gekijou%20-%20Coji-Coji%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Momoko%20Gekijou%20-%20Coji-Coji.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000040000 and rom copier for roms/sdc/Sakura Momoko Gekijou - Coji-Coji.chd"
   },
   "0550300000070000": {
     "id": "0550300000070000",
     "name": "Sakura Taisen - Disc 1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000060000 and rom copier for roms/sdc/Sakura Taisen - Disc 1.chd"
   },
   "0550300000090000": {
     "id": "0550300000090000",
     "name": "Sakura Taisen - Disc 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000080000 and rom copier for roms/sdc/Sakura Taisen - Disc 2.chd"
   },
   "05503000000B0000": {
     "id": "05503000000B0000",
     "name": "Sakura Taisen - Hanagumi Taisen Columns 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%20-%20Hanagumi%20Taisen%20Columns%202%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%20-%20Hanagumi%20Taisen%20Columns%202.png",
     "region": "US",
     "description": "Forwarder installer for 05503000000a0000 and rom copier for roms/sdc/Sakura Taisen - Hanagumi Taisen Columns 2.chd"
   },
   "05503000000D0000": {
     "id": "05503000000D0000",
     "name": "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare - Disc 1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%202%20-%20Kimi,%20Shinitamou%20Koto%20Nakare%20(Japan)%20(Disc%201)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%202%20-%20Kimi,%20Shinitamou%20Koto%20Nakare%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 05503000000c0000 and rom copier for roms/sdc/Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare - Disc 1.chd"
   },
   "05503000000F0000": {
     "id": "05503000000F0000",
     "name": "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare - Disc 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%202%20-%20Kimi,%20Shinitamou%20Koto%20Nakare%20(Japan)%20(Disc%201)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%202%20-%20Kimi,%20Shinitamou%20Koto%20Nakare%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 05503000000e0000 and rom copier for roms/sdc/Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare - Disc 2.chd"
   },
   "0550300000110000": {
     "id": "0550300000110000",
     "name": "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare - Disc 3 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%202%20-%20Kimi,%20Shinitamou%20Koto%20Nakare%20(Japan)%20(Disc%201)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%202%20-%20Kimi,%20Shinitamou%20Koto%20Nakare%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000100000 and rom copier for roms/sdc/Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare - Disc 3.chd"
   },
   "0550300000130000": {
     "id": "0550300000130000",
     "name": "Sakura Taisen 3 - Les Chattes Noires [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%203%20-%20Les%20Chattes%20Noires%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%203%20-%20Les%20Chattes%20Noires.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000120000 and rom copier for roms/sdc/Sakura Taisen 3 - Les Chattes Noires.chd"
   },
   "0550300000150000": {
     "id": "0550300000150000",
     "name": "Sakura Taisen 3 - Paris wa Moeteiru ka - Disc 1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%203%20-%20Paris%20wa%20Moeteiru%20ka%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%203%20-%20Paris%20wa%20Moeteiru%20ka%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000140000 and rom copier for roms/sdc/Sakura Taisen 3 - Paris wa Moeteiru ka - Disc 1.chd"
   },
   "0550300000170000": {
     "id": "0550300000170000",
     "name": "Sakura Taisen 3 - Paris wa Moeteiru ka - Disc 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%203%20-%20Paris%20wa%20Moeteiru%20ka%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%203%20-%20Paris%20wa%20Moeteiru%20ka%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000160000 and rom copier for roms/sdc/Sakura Taisen 3 - Paris wa Moeteiru ka - Disc 2.chd"
   },
   "0550300000190000": {
     "id": "0550300000190000",
     "name": "Sakura Taisen 3 - Paris wa Moeteiru ka - Disc 3 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%203%20-%20Paris%20wa%20Moeteiru%20ka%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%203%20-%20Paris%20wa%20Moeteiru%20ka%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000180000 and rom copier for roms/sdc/Sakura Taisen 3 - Paris wa Moeteiru ka - Disc 3.chd"
   },
   "05503000001B0000": {
     "id": "05503000001B0000",
     "name": "Sakura Taisen 3 - Paris wa Moeteiru ka - Drama Download Disc [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%203%20-%20Paris%20wa%20Moeteiru%20ka%20-%20Drama%20Download%20Disc%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%203%20-%20Paris%20wa%20Moeteiru%20ka%20-%20Drama%20Download%20Disc.png",
     "region": "US",
     "description": "Forwarder installer for 05503000001a0000 and rom copier for roms/sdc/Sakura Taisen 3 - Paris wa Moeteiru ka - Drama Download Disc.chd"
   },
   "05503000001D0000": {
     "id": "05503000001D0000",
     "name": "Sakura Taisen 3 - Paris wa Moeteiru ka - Sakura Taisen 3 Movie Disc [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%203%20-%20Paris%20wa%20Moeteiru%20ka%20-%20Sakura%20Taisen%203%20Movie%20Disc%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%203%20-%20Paris%20wa%20Moeteiru%20ka%20-%20Sakura%20Taisen%203%20Movie%20Disc.png",
     "region": "US",
     "description": "Forwarder installer for 05503000001c0000 and rom copier for roms/sdc/Sakura Taisen 3 - Paris wa Moeteiru ka - Sakura Taisen 3 Movie Disc.chd"
   },
   "05503000001F0000": {
     "id": "05503000001F0000",
     "name": "Sakura Taisen 4 - Koi Seyo Otome [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%204%20-%20Koi%20Seyo%20Otome%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%204%20-%20Koi%20Seyo%20Otome.png",
     "region": "US",
     "description": "Forwarder installer for 05503000001e0000 and rom copier for roms/sdc/Sakura Taisen 4 - Koi Seyo Otome.chd"
   },
   "0550300000210000": {
     "id": "0550300000210000",
     "name": "Sakura Taisen Kinematron Hanagumi Mail [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%20Kinematron%20Hanagumi%20Mail%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%20Kinematron%20Hanagumi%20Mail.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000200000 and rom copier for roms/sdc/Sakura Taisen Kinematron Hanagumi Mail.chd"
   },
   "0550300000230000": {
     "id": "0550300000230000",
     "name": "Sakura Taisen Online - Paris no Yuugana Hibi [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%20Online%20-%20Paris%20no%20Yuugana%20Hibi%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%20Online%20-%20Paris%20no%20Yuugana%20Hibi.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000220000 and rom copier for roms/sdc/Sakura Taisen Online - Paris no Yuugana Hibi.chd"
   },
   "0550300000250000": {
     "id": "0550300000250000",
     "name": "Sakura Taisen Online - Teito no Nagai Hibi [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%20Online%20-%20Teito%20no%20Nagai%20Hibi%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%20Online%20-%20Teito%20no%20Nagai%20Hibi.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000240000 and rom copier for roms/sdc/Sakura Taisen Online - Teito no Nagai Hibi.chd"
   },
   "0550300000270000": {
     "id": "0550300000270000",
     "name": "Sakura Taisen [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sakura%20Taisen%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000260000 and rom copier for roms/sdc/Sakura Taisen.chd"
   },
   "0550300000290000": {
     "id": "0550300000290000",
     "name": "Samba de Amigo Ver. 2000 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Samba%20de%20Amigo%20Ver.%202000%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Samba%20de%20Amigo%20Ver.%202000.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000280000 and rom copier for roms/sdc/Samba de Amigo Ver. 2000.chd"
   },
   "05503000002B0000": {
     "id": "05503000002B0000",
     "name": "Samba de Amigo [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Samba%20de%20Amigo%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Samba%20de%20Amigo.png",
     "region": "US",
     "description": "Forwarder installer for 05503000002a0000 and rom copier for roms/sdc/Samba de Amigo.chd"
   },
   "05503000002D0000": {
     "id": "05503000002D0000",
     "name": "San Francisco Rush 2049 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/San%20Francisco%20Rush%202049%20(Europe)%20(En,Fr,De,Es,It,Nl).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/San%20Francisco%20Rush%202049.png",
     "region": "US",
     "description": "Forwarder installer for 05503000002c0000 and rom copier for roms/sdc/San Francisco Rush 2049.chd"
   },
   "05503000002F0000": {
     "id": "05503000002F0000",
     "name": "Sangokushi VI with Power-Up Kit  [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sangokushi%20VI%20with%20Power-Up%20Kit%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sangokushi%20VI%20with%20Power-Up%20Kit.png",
     "region": "US",
     "description": "Forwarder installer for 05503000002e0000 and rom copier for roms/sdc/Sangokushi VI with Power-Up Kit .chd"
   },
   "0550300000310000": {
     "id": "0550300000310000",
     "name": "Sangokushi VI [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sangokushi%20VI%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sangokushi%20VI.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000300000 and rom copier for roms/sdc/Sangokushi VI.chd"
   },
   "0550300000330000": {
     "id": "0550300000330000",
     "name": "Seaman Esa Disc - Kimos Shu no Youchuu Hojuu Kit [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Angel%20Wish%20-%20Kimi%20no%20Egao%20ni%20Chu!%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Angel%20Wish%20-%20Kimi%20no%20Egao%20ni%20Chu!.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000320000 and rom copier for roms/sdc/Seaman Esa Disc - Kimos Shu no Youchuu Hojuu Kit.chd"
   },
   "0550300000350000": {
     "id": "0550300000350000",
     "name": "Seaman [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Seaman%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Seaman.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000340000 and rom copier for roms/sdc/Seaman.chd"
   },
   "0550300000370000": {
     "id": "0550300000370000",
     "name": "Sega Bass Fishing 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sega%20Bass%20Fishing%202%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sega%20Bass%20Fishing%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000360000 and rom copier for roms/sdc/Sega Bass Fishing 2.chd"
   },
   "0550300000390000": {
     "id": "0550300000390000",
     "name": "Sega Bass Fishing [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sega%20Bass%20Fishing%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sega%20Bass%20Fishing.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000380000 and rom copier for roms/sdc/Sega Bass Fishing.chd"
   },
   "05503000003B0000": {
     "id": "05503000003B0000",
     "name": "Sega Extreme Sports [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sega%20Extreme%20Sports%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sega%20Extreme%20Sports.png",
     "region": "US",
     "description": "Forwarder installer for 05503000003a0000 and rom copier for roms/sdc/Sega Extreme Sports.chd"
   },
   "05503000003D0000": {
     "id": "05503000003D0000",
     "name": "Sega GT - Homologation Special [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sega%20GT%20-%20Homologation%20Special%20(Japan)%20(Taikenban).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sega%20GT%20-%20Homologation%20Special.png",
     "region": "US",
     "description": "Forwarder installer for 05503000003c0000 and rom copier for roms/sdc/Sega GT - Homologation Special.chd"
   },
   "05503000003F0000": {
     "id": "05503000003F0000",
     "name": "Sega GT [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sega%20GT%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sega%20GT.png",
     "region": "US",
     "description": "Forwarder installer for 05503000003e0000 and rom copier for roms/sdc/Sega GT.chd"
   },
   "0550300000410000": {
     "id": "0550300000410000",
     "name": "Sega Marine Fishing [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sega%20Marine%20Fishing%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sega%20Marine%20Fishing.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000400000 and rom copier for roms/sdc/Sega Marine Fishing.chd"
   },
   "0550300000430000": {
     "id": "0550300000430000",
     "name": "Sega Rally 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sega%20Rally%202%20(Europe)%20(Rev%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sega%20Rally%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000420000 and rom copier for roms/sdc/Sega Rally 2.chd"
   },
   "0550300000450000": {
     "id": "0550300000450000",
     "name": "Sega Smash Pack - Volume 1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sega%20Smash%20Pack%20-%20Volume%201%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sega%20Smash%20Pack%20-%20Volume%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000440000 and rom copier for roms/sdc/Sega Smash Pack - Volume 1.chd"
   },
   "0550300000470000": {
     "id": "0550300000470000",
     "name": "Sega Tetris Rev A [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sega%20Tetris%20(Japan)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sega%20Tetris%20Rev%20A.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000460000 and rom copier for roms/sdc/Sega Tetris Rev A.chd"
   },
   "0550300000490000": {
     "id": "0550300000490000",
     "name": "Sega Worldwide Soccer 2000 - Euro Edition [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sega%20Worldwide%20Soccer%202000%20-%20Euro%20Edition%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sega%20Worldwide%20Soccer%202000%20-%20Euro%20Edition.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000480000 and rom copier for roms/sdc/Sega Worldwide Soccer 2000 - Euro Edition.chd"
   },
   "05503000004B0000": {
     "id": "05503000004B0000",
     "name": "Sega Worldwide Soccer 2000 Beta [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sega%20Worldwide%20Soccer%202000%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sega%20Worldwide%20Soccer%202000.png",
     "region": "US",
     "description": "Forwarder installer for 05503000004a0000 and rom copier for roms/sdc/Sega Worldwide Soccer 2000 Beta.chd"
   },
   "05503000004D0000": {
     "id": "05503000004D0000",
     "name": "Sega Worldwide Soccer 2000 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sega%20Worldwide%20Soccer%202000%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sega%20Worldwide%20Soccer%202000.png",
     "region": "US",
     "description": "Forwarder installer for 05503000004c0000 and rom copier for roms/sdc/Sega Worldwide Soccer 2000.chd"
   },
   "05503000004F0000": {
     "id": "05503000004F0000",
     "name": "SegaKara for Dreamcast [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jinsei%20Game%20for%20Dreamcast%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Jinsei%20Game%20for%20Dreamcast.png",
     "region": "US",
     "description": "Forwarder installer for 05503000004e0000 and rom copier for roms/sdc/SegaKara for Dreamcast.chd"
   },
   "0550300000510000": {
     "id": "0550300000510000",
     "name": "Seireiki Rayblade [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Seireiki%20Rayblade%20(Japan)%20(Video%20ROM).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Seireiki%20Rayblade.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000500000 and rom copier for roms/sdc/Seireiki Rayblade.chd"
   },
   "0550300000530000": {
     "id": "0550300000530000",
     "name": "Sekai Fushigi Hakken! Troia [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sekai%20Fushigi%20Hakken!%20Troia%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sekai%20Fushigi%20Hakken!%20Troia.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000520000 and rom copier for roms/sdc/Sekai Fushigi Hakken! Troia.chd"
   },
   "0550300000550000": {
     "id": "0550300000550000",
     "name": "Sengoku Turb - Fanfan I Love Me Dunce-doublentendre [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sengoku%20Turb%20-%20Fanfan%20I%20Love%20Me%20Dunce-doublentendre%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sengoku%20Turb%20-%20Fanfan%20I%20Love%20Me%20Dunce-doublentendre.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000540000 and rom copier for roms/sdc/Sengoku Turb - Fanfan I Love Me Dunce-doublentendre.chd"
   },
   "0550300000570000": {
     "id": "0550300000570000",
     "name": "Sengoku Turb [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sengoku%20Turb%20(Japan)%20(Taikenban).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sengoku%20Turb.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000560000 and rom copier for roms/sdc/Sengoku Turb.chd"
   },
   "0550300000590000": {
     "id": "0550300000590000",
     "name": "Sentimental Graffiti - Yakusoku [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sentimental%20Graffiti%20-%20Yakusoku%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sentimental%20Graffiti%20-%20Yakusoku.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000580000 and rom copier for roms/sdc/Sentimental Graffiti - Yakusoku.chd"
   },
   "05503000005B0000": {
     "id": "05503000005B0000",
     "name": "Sentimental Graffiti 2 - Disc 1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sentimental%20Graffiti%20-%20Yakusoku%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sentimental%20Graffiti%20-%20Yakusoku.png",
     "region": "US",
     "description": "Forwarder installer for 05503000005a0000 and rom copier for roms/sdc/Sentimental Graffiti 2 - Disc 1.chd"
   },
   "05503000005D0000": {
     "id": "05503000005D0000",
     "name": "Sentimental Graffiti 2 - Disc 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sentimental%20Graffiti%20-%20Yakusoku%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sentimental%20Graffiti%20-%20Yakusoku.png",
     "region": "US",
     "description": "Forwarder installer for 05503000005c0000 and rom copier for roms/sdc/Sentimental Graffiti 2 - Disc 2.chd"
   },
   "05503000005F0000": {
     "id": "05503000005F0000",
     "name": "Sentimental Graffiti 2 - Third Window [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sentimental%20Graffiti%20-%20Yakusoku%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sentimental%20Graffiti%20-%20Yakusoku.png",
     "region": "US",
     "description": "Forwarder installer for 05503000005e0000 and rom copier for roms/sdc/Sentimental Graffiti 2 - Third Window.chd"
   },
   "0550300000610000": {
     "id": "0550300000610000",
     "name": "Seventh Cross Evolution [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Seventh%20Cross%20Evolution%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Seventh%20Cross%20Evolution.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000600000 and rom copier for roms/sdc/Seventh Cross Evolution.chd"
   },
   "0550300000630000": {
     "id": "0550300000630000",
     "name": "SGGG - Segagaga [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/SGGG%20-%20Segagaga%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/SGGG%20-%20Segagaga.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000620000 and rom copier for roms/sdc/SGGG - Segagaga.chd"
   },
   "0550300000650000": {
     "id": "0550300000650000",
     "name": "Shadow Man [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shadow%20Man%20(Europe)%20(En,Fr,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shadow%20Man.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000640000 and rom copier for roms/sdc/Shadow Man.chd"
   },
   "0550300000670000": {
     "id": "0550300000670000",
     "name": "Shanghai - Dynasty [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shanghai%20-%20Dynasty%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shanghai%20-%20Dynasty.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000660000 and rom copier for roms/sdc/Shanghai - Dynasty.chd"
   },
   "0550300000690000": {
     "id": "0550300000690000",
     "name": "Shenmue - Disc 1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shenmue%20II%20(Europe)%20(En,Fr,De,Es)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shenmue%20II%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000680000 and rom copier for roms/sdc/Shenmue - Disc 1.chd"
   },
   "05503000006B0000": {
     "id": "05503000006B0000",
     "name": "Shenmue - Disc 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shenmue%20II%20(Europe)%20(En,Fr,De,Es)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shenmue%20II%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 05503000006a0000 and rom copier for roms/sdc/Shenmue - Disc 2.chd"
   },
   "05503000006D0000": {
     "id": "05503000006D0000",
     "name": "Shenmue - Disc 3 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shenmue%20II%20(Europe)%20(En,Fr,De,Es)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shenmue%20II%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 05503000006c0000 and rom copier for roms/sdc/Shenmue - Disc 3.chd"
   },
   "05503000006F0000": {
     "id": "05503000006F0000",
     "name": "Shenmue - Ichishou Yokosuka - Disc 1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shenmue%20-%20Ichishou%20Yokosuka%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shenmue%20-%20Ichishou%20Yokosuka%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 05503000006e0000 and rom copier for roms/sdc/Shenmue - Ichishou Yokosuka - Disc 1.chd"
   },
   "0550300000710000": {
     "id": "0550300000710000",
     "name": "Shenmue - Ichishou Yokosuka - Disc 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shenmue%20-%20Ichishou%20Yokosuka%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shenmue%20-%20Ichishou%20Yokosuka%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000700000 and rom copier for roms/sdc/Shenmue - Ichishou Yokosuka - Disc 2.chd"
   },
   "0550300000730000": {
     "id": "0550300000730000",
     "name": "Shenmue - Ichishou Yokosuka - Disc 3 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shenmue%20-%20Ichishou%20Yokosuka%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shenmue%20-%20Ichishou%20Yokosuka%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000720000 and rom copier for roms/sdc/Shenmue - Ichishou Yokosuka - Disc 3.chd"
   },
   "0550300000750000": {
     "id": "0550300000750000",
     "name": "Shenmue - Ichishou Yokosuka [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shenmue%20-%20Ichishou%20Yokosuka%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shenmue%20-%20Ichishou%20Yokosuka%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000740000 and rom copier for roms/sdc/Shenmue - Ichishou Yokosuka.chd"
   },
   "0550300000770000": {
     "id": "0550300000770000",
     "name": "Shenmue II - Disc 1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shenmue%20II%20(Europe)%20(En,Fr,De,Es)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shenmue%20II%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000760000 and rom copier for roms/sdc/Shenmue II - Disc 1.chd"
   },
   "0550300000790000": {
     "id": "0550300000790000",
     "name": "Shenmue II - Disc 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shenmue%20II%20(Europe)%20(En,Fr,De,Es)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shenmue%20II%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000780000 and rom copier for roms/sdc/Shenmue II - Disc 2.chd"
   },
   "05503000007B0000": {
     "id": "05503000007B0000",
     "name": "Shenmue II - Disc 3 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shenmue%20II%20(Europe)%20(En,Fr,De,Es)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shenmue%20II%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 05503000007a0000 and rom copier for roms/sdc/Shenmue II - Disc 3.chd"
   },
   "05503000007D0000": {
     "id": "05503000007D0000",
     "name": "Shenmue II - Disc 4 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shenmue%20II%20(Europe)%20(En,Fr,De,Es)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shenmue%20II%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 05503000007c0000 and rom copier for roms/sdc/Shenmue II - Disc 4.chd"
   },
   "05503000007F0000": {
     "id": "05503000007F0000",
     "name": "Shenmue [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shenmue%20(Europe)%20(En,Fr,De,Es)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shenmue%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 05503000007e0000 and rom copier for roms/sdc/Shenmue.chd"
   },
   "0550300000810000": {
     "id": "0550300000810000",
     "name": "Shikigami no Shiro II [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shikigami%20no%20Shiro%20II%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shikigami%20no%20Shiro%20II.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000800000 and rom copier for roms/sdc/Shikigami no Shiro II.chd"
   },
   "0550300000830000": {
     "id": "0550300000830000",
     "name": "Shin Honkaku Hanafuda [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shin%20Honkaku%20Hanafuda%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shin%20Honkaku%20Hanafuda.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000820000 and rom copier for roms/sdc/Shin Honkaku Hanafuda.chd"
   },
   "0550300000850000": {
     "id": "0550300000850000",
     "name": "Shin Nihon Pro Wrestling - Toukon Retsuden 4 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shin%20Nihon%20Pro%20Wrestling%20-%20Toukon%20Retsuden%204%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shin%20Nihon%20Pro%20Wrestling%20-%20Toukon%20Retsuden%204.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000840000 and rom copier for roms/sdc/Shin Nihon Pro Wrestling - Toukon Retsuden 4.chd"
   },
   "0550300000870000": {
     "id": "0550300000870000",
     "name": "Shin Seiki Evangelion - Ayanami Ikusei Keikaku [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shin%20Seiki%20Evangelion%20-%20Ayanami%20Ikusei%20Keikaku%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shin%20Seiki%20Evangelion%20-%20Ayanami%20Ikusei%20Keikaku.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000860000 and rom copier for roms/sdc/Shin Seiki Evangelion - Ayanami Ikusei Keikaku.chd"
   },
   "0550300000890000": {
     "id": "0550300000890000",
     "name": "Shin Seiki Evangelion - Typing E Keikaku [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shin%20Seiki%20Evangelion%20-%20Typing%20E%20Keikaku%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shin%20Seiki%20Evangelion%20-%20Typing%20E%20Keikaku.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000880000 and rom copier for roms/sdc/Shin Seiki Evangelion - Typing E Keikaku.chd"
   },
   "05503000008B0000": {
     "id": "05503000008B0000",
     "name": "Shin Seiki Evangelion - Typing Hokan Keikaku [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shin%20Seiki%20Evangelion%20-%20Typing%20Hokan%20Keikaku%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shin%20Seiki%20Evangelion%20-%20Typing%20Hokan%20Keikaku.png",
     "region": "US",
     "description": "Forwarder installer for 05503000008a0000 and rom copier for roms/sdc/Shin Seiki Evangelion - Typing Hokan Keikaku.chd"
   },
   "05503000008D0000": {
     "id": "05503000008D0000",
     "name": "Shinki Sekai Evolution 2 - Tooi Yakusoku [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shinki%20Sekai%20Evolution%202%20-%20Tooi%20Yakusoku%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shinki%20Sekai%20Evolution%202%20-%20Tooi%20Yakusoku.png",
     "region": "US",
     "description": "Forwarder installer for 05503000008c0000 and rom copier for roms/sdc/Shinki Sekai Evolution 2 - Tooi Yakusoku.chd"
   },
   "05503000008F0000": {
     "id": "05503000008F0000",
     "name": "Shinki Sekai Evolution [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shinki%20Sekai%20Evolution%20(Japan)%20(Taikenban).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shinki%20Sekai%20Evolution.png",
     "region": "US",
     "description": "Forwarder installer for 05503000008e0000 and rom copier for roms/sdc/Shinki Sekai Evolution.chd"
   },
   "0550300000910000": {
     "id": "0550300000910000",
     "name": "Shirotsumesouwa - Episode of the Clovers [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shirotsumesouwa%20-%20Episode%20of%20the%20Clovers%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shirotsumesouwa%20-%20Episode%20of%20the%20Clovers.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000900000 and rom copier for roms/sdc/Shirotsumesouwa - Episode of the Clovers.chd"
   },
   "0550300000930000": {
     "id": "0550300000930000",
     "name": "Shutokou Battle 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shutokou%20Battle%202%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shutokou%20Battle%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000920000 and rom copier for roms/sdc/Shutokou Battle 2.chd"
   },
   "0550300000950000": {
     "id": "0550300000950000",
     "name": "Shutokou Battle [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shutokou%20Battle%20(Japan)%20(Taikenban).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shutokou%20Battle.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000940000 and rom copier for roms/sdc/Shutokou Battle.chd"
   },
   "0550300000970000": {
     "id": "0550300000970000",
     "name": "Silent Scope [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Silent%20Scope%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Silent%20Scope.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000960000 and rom copier for roms/sdc/Silent Scope.chd"
   },
   "0550300000990000": {
     "id": "0550300000990000",
     "name": "Silver [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Silver%20(Europe)%20(En,Nl).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Silver.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000980000 and rom copier for roms/sdc/Silver.chd"
   },
   "05503000009B0000": {
     "id": "05503000009B0000",
     "name": "Simple 2000 Series DC Vol. 01 - Bittersweet Fools - The Ren'ai Adventure [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Simple%202000%20Series%20DC%20Vol.%2001%20-%20Bittersweet%20Fools%20-%20The%20Ren'ai%20Adventure%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Simple%202000%20Series%20DC%20Vol.%2001%20-%20Bittersweet%20Fools%20-%20The%20Ren'ai%20Adventure.png",
     "region": "US",
     "description": "Forwarder installer for 05503000009a0000 and rom copier for roms/sdc/Simple 2000 Series DC Vol. 01 - Bittersweet Fools - The Ren'ai Adventure.chd"
   },
   "05503000009D0000": {
     "id": "05503000009D0000",
     "name": "Simple 2000 Series DC Vol. 02 - Natsuiro Celebration - The Ren'ai Simulation [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Simple%202000%20Series%20DC%20Vol.%2002%20-%20Natsuiro%20Celebration%20-%20The%20Ren'ai%20Simulation%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Simple%202000%20Series%20DC%20Vol.%2002%20-%20Natsuiro%20Celebration%20-%20The%20Ren'ai%20Simulation.png",
     "region": "US",
     "description": "Forwarder installer for 05503000009c0000 and rom copier for roms/sdc/Simple 2000 Series DC Vol. 02 - Natsuiro Celebration - The Ren'ai Simulation.chd"
   },
   "05503000009F0000": {
     "id": "05503000009F0000",
     "name": "Simple 2000 Series DC Vol. 03 - Fureai - The Ren'ai Simulation  [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Simple%202000%20Series%20DC%20Vol.%2003%20-%20Fureai%20-%20The%20Ren'ai%20Simulation%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Simple%202000%20Series%20DC%20Vol.%2003%20-%20Fureai%20-%20The%20Ren'ai%20Simulation.png",
     "region": "US",
     "description": "Forwarder installer for 05503000009e0000 and rom copier for roms/sdc/Simple 2000 Series DC Vol. 03 - Fureai - The Ren'ai Simulation .chd"
   },
   "0550300000A10000": {
     "id": "0550300000A10000",
     "name": "Simple 2000 Series DC Vol. 04 - Okaeri! The Ren'ai Adventure [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Simple%202000%20Series%20DC%20Vol.%2004%20-%20Okaeri!%20The%20Ren'ai%20Adventure%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Simple%202000%20Series%20DC%20Vol.%2004%20-%20Okaeri!%20The%20Ren'ai%20Adventure.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000a00000 and rom copier for roms/sdc/Simple 2000 Series DC Vol. 04 - Okaeri! The Ren'ai Adventure.chd"
   },
   "0550300000A30000": {
     "id": "0550300000A30000",
     "name": "Sister Princess - Premium Edition - Disc 1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sister%20Princess%20-%20Premium%20Edition%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sister%20Princess%20-%20Premium%20Edition%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000a20000 and rom copier for roms/sdc/Sister Princess - Premium Edition - Disc 1.chd"
   },
   "0550300000A50000": {
     "id": "0550300000A50000",
     "name": "Sister Princess - Premium Edition - Disc 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sister%20Princess%20-%20Premium%20Edition%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sister%20Princess%20-%20Premium%20Edition%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000a40000 and rom copier for roms/sdc/Sister Princess - Premium Edition - Disc 2.chd"
   },
   "0550300000A70000": {
     "id": "0550300000A70000",
     "name": "Skies of Arcadia - Disc 1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Skies%20of%20Arcadia%20(Europe)%20(En,Fr,De,Es)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Skies%20of%20Arcadia%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000a60000 and rom copier for roms/sdc/Skies of Arcadia - Disc 1.chd"
   },
   "0550300000A90000": {
     "id": "0550300000A90000",
     "name": "Skies of Arcadia - Disc 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Skies%20of%20Arcadia%20(Europe)%20(En,Fr,De,Es)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Skies%20of%20Arcadia%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000a80000 and rom copier for roms/sdc/Skies of Arcadia - Disc 2.chd"
   },
   "0550300000AB0000": {
     "id": "0550300000AB0000",
     "name": "Slave Zero [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Slave%20Zero%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Slave%20Zero.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000aa0000 and rom copier for roms/sdc/Slave Zero.chd"
   },
   "0550300000AD0000": {
     "id": "0550300000AD0000",
     "name": "SnoCross Championship Racing [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/SnoCross%20Championship%20Racing%20(Europe)%20(En,Fr,De).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/SnoCross%20Championship%20Racing.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000ac0000 and rom copier for roms/sdc/SnoCross Championship Racing.chd"
   },
   "0550300000AF0000": {
     "id": "0550300000AF0000",
     "name": "Snow Surfers [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Snow%20Surfers%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Snow%20Surfers.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000ae0000 and rom copier for roms/sdc/Snow Surfers.chd"
   },
   "0550300000B10000": {
     "id": "0550300000B10000",
     "name": "Snow [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Snow%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Snow.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000b00000 and rom copier for roms/sdc/Snow.chd"
   },
   "0550300000B30000": {
     "id": "0550300000B30000",
     "name": "Soldier of Fortune [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Soldier%20of%20Fortune%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Soldier%20of%20Fortune.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000b20000 and rom copier for roms/sdc/Soldier of Fortune.chd"
   },
   "0550300000B50000": {
     "id": "0550300000B50000",
     "name": "Sonic Adventure - Limited Edition [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sonic%20Adventure%20-%20Limited%20Edition%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sonic%20Adventure%20-%20Limited%20Edition.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000b40000 and rom copier for roms/sdc/Sonic Adventure - Limited Edition.chd"
   },
   "0550300000B70000": {
     "id": "0550300000B70000",
     "name": "Sonic Adventure 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sonic%20Adventure%202%20(Europe)%20(En,Ja,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sonic%20Adventure%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000b60000 and rom copier for roms/sdc/Sonic Adventure 2.chd"
   },
   "0550300000B90000": {
     "id": "0550300000B90000",
     "name": "Sonic Adventure International [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sonic%20Adventure%20International%20(Japan)%20(En,Ja,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sonic%20Adventure%20International.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000b80000 and rom copier for roms/sdc/Sonic Adventure International.chd"
   },
   "0550300000BB0000": {
     "id": "0550300000BB0000",
     "name": "Sonic Adventure [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sonic%20Adventure%20(Europe)%20(En,Ja,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sonic%20Adventure.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000ba0000 and rom copier for roms/sdc/Sonic Adventure.chd"
   },
   "0550300000BD0000": {
     "id": "0550300000BD0000",
     "name": "Sonic Shuffle [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sonic%20Shuffle%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sonic%20Shuffle.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000bc0000 and rom copier for roms/sdc/Sonic Shuffle.chd"
   },
   "0550300000BF0000": {
     "id": "0550300000BF0000",
     "name": "Sorcerian - Shichisei Mahou no Shito [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sorcerian%20-%20Shichisei%20Mahou%20no%20Shito%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sorcerian%20-%20Shichisei%20Mahou%20no%20Shito.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000be0000 and rom copier for roms/sdc/Sorcerian - Shichisei Mahou no Shito.chd"
   },
   "0550300000C10000": {
     "id": "0550300000C10000",
     "name": "Soukou no Kihei - Space Griffon [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Soukou%20no%20Kihei%20-%20Space%20Griffon%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Soukou%20no%20Kihei%20-%20Space%20Griffon.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000c00000 and rom copier for roms/sdc/Soukou no Kihei - Space Griffon.chd"
   },
   "0550300000C30000": {
     "id": "0550300000C30000",
     "name": "Soul Fighter [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Soul%20Fighter%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Soul%20Fighter.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000c20000 and rom copier for roms/sdc/Soul Fighter.chd"
   },
   "0550300000C50000": {
     "id": "0550300000C50000",
     "name": "Soulcalibur [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Soulcalibur%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Soulcalibur.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000c40000 and rom copier for roms/sdc/Soulcalibur.chd"
   },
   "0550300000C70000": {
     "id": "0550300000C70000",
     "name": "South Park - Chef's Luv Shack [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/South%20Park%20-%20Chef's%20Luv%20Shack%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/South%20Park%20-%20Chef's%20Luv%20Shack.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000c60000 and rom copier for roms/sdc/South Park - Chef's Luv Shack.chd"
   },
   "0550300000C90000": {
     "id": "0550300000C90000",
     "name": "South Park Rally [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/South%20Park%20Rally%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/South%20Park%20Rally.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000c80000 and rom copier for roms/sdc/South Park Rally.chd"
   },
   "0550300000CB0000": {
     "id": "0550300000CB0000",
     "name": "Space Channel 5 Part 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Space%20Channel%205%20Part%202%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Space%20Channel%205%20Part%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000ca0000 and rom copier for roms/sdc/Space Channel 5 Part 2.chd"
   },
   "0550300000CD0000": {
     "id": "0550300000CD0000",
     "name": "Space Channel 5 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Space%20Channel%205%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Space%20Channel%205.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000cc0000 and rom copier for roms/sdc/Space Channel 5.chd"
   },
   "0550300000CF0000": {
     "id": "0550300000CF0000",
     "name": "Spawn - In the Demon's Hand [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Spawn%20-%20In%20the%20Demon's%20Hand%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Spawn%20-%20In%20the%20Demon's%20Hand.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000ce0000 and rom copier for roms/sdc/Spawn - In the Demon's Hand.chd"
   },
   "0550300000D10000": {
     "id": "0550300000D10000",
     "name": "Spec Ops II - Omega Squad [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Spec%20Ops%20II%20-%20Omega%20Squad%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Spec%20Ops%20II%20-%20Omega%20Squad.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000d00000 and rom copier for roms/sdc/Spec Ops II - Omega Squad.chd"
   },
   "0550300000D30000": {
     "id": "0550300000D30000",
     "name": "Speed Devils - Online Racing [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Speed%20Devils%20-%20Online%20Racing%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Speed%20Devils%20-%20Online%20Racing.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000d20000 and rom copier for roms/sdc/Speed Devils - Online Racing.chd"
   },
   "0550300000D50000": {
     "id": "0550300000D50000",
     "name": "Speed Devils [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Speed%20Devils%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Speed%20Devils.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000d40000 and rom copier for roms/sdc/Speed Devils.chd"
   },
   "0550300000D70000": {
     "id": "0550300000D70000",
     "name": "Spider-Man [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Spider-Man%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Spider-Man.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000d60000 and rom copier for roms/sdc/Spider-Man.chd"
   },
   "0550300000D90000": {
     "id": "0550300000D90000",
     "name": "Spirit of Speed 1937 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Spirit%20of%20Speed%201937%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Spirit%20of%20Speed%201937.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000d80000 and rom copier for roms/sdc/Spirit of Speed 1937.chd"
   },
   "0550300000DB0000": {
     "id": "0550300000DB0000",
     "name": "Sports Jam [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sports%20Jam%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sports%20Jam.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000da0000 and rom copier for roms/sdc/Sports Jam.chd"
   },
   "0550300000DD0000": {
     "id": "0550300000DD0000",
     "name": "Star Gladiator 2 - Nightmare of Bilstein [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Star%20Gladiator%202%20-%20Nightmare%20of%20Bilstein%20(Japan)%20(Tentou%20Taikenban).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Star%20Gladiator%202%20-%20Nightmare%20of%20Bilstein.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000dc0000 and rom copier for roms/sdc/Star Gladiator 2 - Nightmare of Bilstein.chd"
   },
   "0550300000DF0000": {
     "id": "0550300000DF0000",
     "name": "Star Wars - Demolition [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Star%20Wars%20-%20Demolition%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Star%20Wars%20-%20Demolition.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000de0000 and rom copier for roms/sdc/Star Wars - Demolition.chd"
   },
   "0550300000E10000": {
     "id": "0550300000E10000",
     "name": "Star Wars - Episode I - Jedi Power Battles [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Star%20Wars%20-%20Episode%20I%20-%20Jedi%20Power%20Battles%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Star%20Wars%20-%20Episode%20I%20-%20Jedi%20Power%20Battles.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000e00000 and rom copier for roms/sdc/Star Wars - Episode I - Jedi Power Battles.chd"
   },
   "0550300000E30000": {
     "id": "0550300000E30000",
     "name": "Star Wars - Episode I - Racer [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Star%20Wars%20-%20Episode%20I%20-%20Racer%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Star%20Wars%20-%20Episode%20I%20-%20Racer.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000e20000 and rom copier for roms/sdc/Star Wars - Episode I - Racer.chd"
   },
   "0550300000E50000": {
     "id": "0550300000E50000",
     "name": "StarLancer [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/StarLancer%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/StarLancer.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000e40000 and rom copier for roms/sdc/StarLancer.chd"
   },
   "0550300000E70000": {
     "id": "0550300000E70000",
     "name": "Street Fighter Alpha 3 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Street%20Fighter%20Alpha%203%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Street%20Fighter%20Alpha%203.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000e60000 and rom copier for roms/sdc/Street Fighter Alpha 3.chd"
   },
   "0550300000E90000": {
     "id": "0550300000E90000",
     "name": "Street Fighter III - 3rd Strike [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Street%20Fighter%20III%20-%203rd%20Strike%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Street%20Fighter%20III%20-%203rd%20Strike.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000e80000 and rom copier for roms/sdc/Street Fighter III - 3rd Strike.chd"
   },
   "0550300000EB0000": {
     "id": "0550300000EB0000",
     "name": "Street Fighter III - Double Impact [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Street%20Fighter%20III%20-%20Double%20Impact%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Street%20Fighter%20III%20-%20Double%20Impact.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000ea0000 and rom copier for roms/sdc/Street Fighter III - Double Impact.chd"
   },
   "0550300000ED0000": {
     "id": "0550300000ED0000",
     "name": "Street Fighter III - W Impact [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Street%20Fighter%20III%20-%20W%20Impact%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Street%20Fighter%20III%20-%20W%20Impact.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000ec0000 and rom copier for roms/sdc/Street Fighter III - W Impact.chd"
   },
   "0550300000EF0000": {
     "id": "0550300000EF0000",
     "name": "Street Fighter Zero 3 - Saikyo-ryu Dojo for Matching Service [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Street%20Fighter%20Zero%203%20-%20Saikyo-ryu%20Dojo%20for%20Matching%20Service%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Street%20Fighter%20Zero%203%20-%20Saikyo-ryu%20Dojo%20for%20Matching%20Service.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000ee0000 and rom copier for roms/sdc/Street Fighter Zero 3 - Saikyo-ryu Dojo for Matching Service.chd"
   },
   "0550300000F10000": {
     "id": "0550300000F10000",
     "name": "Street Fighter Zero 3 - Saikyo-ryu Dojo [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Street%20Fighter%20Zero%203%20-%20Saikyo-ryu%20Dojo%20(Japan)%20(Tentou%20Taikenban).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Street%20Fighter%20Zero%203%20-%20Saikyo-ryu%20Dojo.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000f00000 and rom copier for roms/sdc/Street Fighter Zero 3 - Saikyo-ryu Dojo.chd"
   },
   "0550300000F30000": {
     "id": "0550300000F30000",
     "name": "Striker Pro 2000 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Striker%20Pro%202000%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Striker%20Pro%202000.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000f20000 and rom copier for roms/sdc/Striker Pro 2000.chd"
   },
   "0550300000F50000": {
     "id": "0550300000F50000",
     "name": "Stunt GP [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Stunt%20GP%20(Europe)%20(En,Fr,De,Es,It,Nl,Sv).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Stunt%20GP.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000f40000 and rom copier for roms/sdc/Stunt GP.chd"
   },
   "0550300000F70000": {
     "id": "0550300000F70000",
     "name": "Stupid Invaders - Disc 1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Stupid%20Invaders%20(Europe)%20(En,Fr,De,It)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Stupid%20Invaders%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000f60000 and rom copier for roms/sdc/Stupid Invaders - Disc 1.chd"
   },
   "0550300000F90000": {
     "id": "0550300000F90000",
     "name": "Stupid Invaders - Disc 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Stupid%20Invaders%20(Europe)%20(En,Fr,De,It)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Stupid%20Invaders%20-%20Disc%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000f80000 and rom copier for roms/sdc/Stupid Invaders - Disc 2.chd"
   },
   "0550300000FB0000": {
     "id": "0550300000FB0000",
     "name": "Suigetsu - Mayoigokoro - Disc 1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Suigetsu%20-%20Mayoigokoro%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Suigetsu%20-%20Mayoigokoro%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000fa0000 and rom copier for roms/sdc/Suigetsu - Mayoigokoro - Disc 1.chd"
   },
   "0550300000FD0000": {
     "id": "0550300000FD0000",
     "name": "Suigetsu - Mayoigokoro - Disc 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Suigetsu%20-%20Mayoigokoro%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Suigetsu%20-%20Mayoigokoro%20-%20Disc%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000fc0000 and rom copier for roms/sdc/Suigetsu - Mayoigokoro - Disc 2.chd"
   },
   "0550300000FF0000": {
     "id": "0550300000FF0000",
     "name": "Suika [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Suika%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Suika.png",
     "region": "US",
     "description": "Forwarder installer for 0550300000fe0000 and rom copier for roms/sdc/Suika.chd"
   },
   "0550300001010000": {
     "id": "0550300001010000",
     "name": "Sunrise Eiyuutan [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sunrise%20Eiyuutan%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sunrise%20Eiyuutan.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001000000 and rom copier for roms/sdc/Sunrise Eiyuutan.chd"
   },
   "0550300001030000": {
     "id": "0550300001030000",
     "name": "Super Euro Soccer 2000 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Super%20Euro%20Soccer%202000%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Super%20Euro%20Soccer%202000.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001020000 and rom copier for roms/sdc/Super Euro Soccer 2000.chd"
   },
   "0550300001050000": {
     "id": "0550300001050000",
     "name": "Super Magnetic Neo [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Super%20Magnetic%20Neo%20(Europe)%20(En,Fr,De).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Super%20Magnetic%20Neo.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001040000 and rom copier for roms/sdc/Super Magnetic Neo.chd"
   },
   "0550300001070000": {
     "id": "0550300001070000",
     "name": "Super Magnetic Niuniu [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Super%20Magnetic%20Niuniu%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Super%20Magnetic%20Niuniu.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001060000 and rom copier for roms/sdc/Super Magnetic Niuniu.chd"
   },
   "0550300001090000": {
     "id": "0550300001090000",
     "name": "Super Producers - Mezase Show Biz Kai [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Super%20Producers%20-%20Mezase%20Show%20Biz%20Kai%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Super%20Producers%20-%20Mezase%20Show%20Biz%20Kai.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001080000 and rom copier for roms/sdc/Super Producers - Mezase Show Biz Kai.chd"
   },
   "05503000010B0000": {
     "id": "05503000010B0000",
     "name": "Super Puzzle Fighter II X for Matching Service [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Super%20Puzzle%20Fighter%20II%20X%20for%20Matching%20Service%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Super%20Puzzle%20Fighter%20II%20X%20for%20Matching%20Service.png",
     "region": "US",
     "description": "Forwarder installer for 05503000010a0000 and rom copier for roms/sdc/Super Puzzle Fighter II X for Matching Service.chd"
   },
   "05503000010D0000": {
     "id": "05503000010D0000",
     "name": "Super Robot Taisen Alpha [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Super%20Robot%20Taisen%20Alpha%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Super%20Robot%20Taisen%20Alpha.png",
     "region": "US",
     "description": "Forwarder installer for 05503000010c0000 and rom copier for roms/sdc/Super Robot Taisen Alpha.chd"
   },
   "05503000010F0000": {
     "id": "05503000010F0000",
     "name": "Super Runabout - San Francisco Edition [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Super%20Runabout%20-%20San%20Francisco%20Edition%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Super%20Runabout%20-%20San%20Francisco%20Edition.png",
     "region": "US",
     "description": "Forwarder installer for 05503000010e0000 and rom copier for roms/sdc/Super Runabout - San Francisco Edition.chd"
   },
   "0550300001110000": {
     "id": "0550300001110000",
     "name": "Super Runabout [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Super%20Runabout%20(Japan)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Super%20Runabout.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001100000 and rom copier for roms/sdc/Super Runabout.chd"
   },
   "0550300001130000": {
     "id": "0550300001130000",
     "name": "Super Speed Racing [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Super%20Speed%20Racing%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Super%20Speed%20Racing.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001120000 and rom copier for roms/sdc/Super Speed Racing.chd"
   },
   "0550300001150000": {
     "id": "0550300001150000",
     "name": "Super Street Fighter II X for Matching Service [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Super%20Street%20Fighter%20II%20X%20for%20Matching%20Service%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Super%20Street%20Fighter%20II%20X%20for%20Matching%20Service.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001140000 and rom copier for roms/sdc/Super Street Fighter II X for Matching Service.chd"
   },
   "0550300001170000": {
     "id": "0550300001170000",
     "name": "Surf Rocket Racers [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Surf%20Rocket%20Racers%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Surf%20Rocket%20Racers.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001160000 and rom copier for roms/sdc/Surf Rocket Racers.chd"
   },
   "0550300001190000": {
     "id": "0550300001190000",
     "name": "Suzuki Alstare - Extreme Racing [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Suzuki%20Alstare%20-%20Extreme%20Racing%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Suzuki%20Alstare%20-%20Extreme%20Racing.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001180000 and rom copier for roms/sdc/Suzuki Alstare - Extreme Racing.chd"
   },
   "05503000011B0000": {
     "id": "05503000011B0000",
     "name": "Sweet Season [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sweet%20Season%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sweet%20Season.png",
     "region": "US",
     "description": "Forwarder installer for 05503000011a0000 and rom copier for roms/sdc/Sweet Season.chd"
   },
   "05503000011D0000": {
     "id": "05503000011D0000",
     "name": "Sword of the Berserk - Guts' Rage [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sword%20of%20the%20Berserk%20-%20Guts'%20Rage%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sword%20of%20the%20Berserk%20-%20Guts'%20Rage.png",
     "region": "US",
     "description": "Forwarder installer for 05503000011c0000 and rom copier for roms/sdc/Sword of the Berserk - Guts' Rage.chd"
   },
   "05503000011F0000": {
     "id": "05503000011F0000",
     "name": "Sydney 2000 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sydney%202000%20(Australia).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Sydney%202000.png",
     "region": "US",
     "description": "Forwarder installer for 05503000011e0000 and rom copier for roms/sdc/Sydney 2000.chd"
   },
   "0550300001210000": {
     "id": "0550300001210000",
     "name": "Taisen Net Gimmick - Capcom & Psikyo All Stars [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Taisen%20Net%20Gimmick%20-%20Capcom%20_%20Psikyo%20All%20Stars%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Taisen%20Net%20Gimmick%20-%20Capcom%20%26%20Psikyo%20All%20Stars.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001200000 and rom copier for roms/sdc/Taisen Net Gimmick - Capcom & Psikyo All Stars.chd"
   },
   "0550300001230000": {
     "id": "0550300001230000",
     "name": "Tako no Marine [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tako%20no%20Marine%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tako%20no%20Marine.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001220000 and rom copier for roms/sdc/Tako no Marine.chd"
   },
   "0550300001250000": {
     "id": "0550300001250000",
     "name": "Tamakyuu [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tamakyuu%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tamakyuu.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001240000 and rom copier for roms/sdc/Tamakyuu.chd"
   },
   "0550300001270000": {
     "id": "0550300001270000",
     "name": "Tanaka Torahiko no Ultra-ryuu Shougi - Ibisha Anaguma-hen [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tanaka%20Torahiko%20no%20Ultra-ryuu%20Shougi%20-%20Ibisha%20Anaguma-hen%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tanaka%20Torahiko%20no%20Ultra-ryuu%20Shougi%20-%20Ibisha%20Anaguma-hen.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001260000 and rom copier for roms/sdc/Tanaka Torahiko no Ultra-ryuu Shougi - Ibisha Anaguma-hen.chd"
   },
   "0550300001290000": {
     "id": "0550300001290000",
     "name": "Tantei Shinshi Dash! - Rev A [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tantei%20Shinshi%20Dash!%20(Japan)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tantei%20Shinshi%20Dash!.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001280000 and rom copier for roms/sdc/Tantei Shinshi Dash! - Rev A.chd"
   },
   "05503000012B0000": {
     "id": "05503000012B0000",
     "name": "Tantei Shinshi Dash! [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tantei%20Shinshi%20Dash!%20(Japan)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tantei%20Shinshi%20Dash!.png",
     "region": "US",
     "description": "Forwarder installer for 05503000012a0000 and rom copier for roms/sdc/Tantei Shinshi Dash!.chd"
   },
   "05503000012D0000": {
     "id": "05503000012D0000",
     "name": "Taxi 2 - Le Jeu [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Taxi%202%20-%20Le%20Jeu%20(France).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Taxi%202%20-%20Le%20Jeu.png",
     "region": "US",
     "description": "Forwarder installer for 05503000012c0000 and rom copier for roms/sdc/Taxi 2 - Le Jeu.chd"
   },
   "05503000012F0000": {
     "id": "05503000012F0000",
     "name": "Tech Romancer [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tech%20Romancer%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tech%20Romancer.png",
     "region": "US",
     "description": "Forwarder installer for 05503000012e0000 and rom copier for roms/sdc/Tech Romancer.chd"
   },
   "0550300001310000": {
     "id": "0550300001310000",
     "name": "Tee Off [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tee%20Off%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tee%20Off.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001300000 and rom copier for roms/sdc/Tee Off.chd"
   },
   "0550300001330000": {
     "id": "0550300001330000",
     "name": "Tenohira o, Taiyou ni [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tenohira%20o,%20Taiyou%20ni%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tenohira%20o,%20Taiyou%20ni.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001320000 and rom copier for roms/sdc/Tenohira o, Taiyou ni.chd"
   },
   "0550300001350000": {
     "id": "0550300001350000",
     "name": "Tentama - 1st Sunny Side [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tentama%20-%201st%20Sunny%20Side%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tentama%20-%201st%20Sunny%20Side.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001340000 and rom copier for roms/sdc/Tentama - 1st Sunny Side.chd"
   },
   "0550300001370000": {
     "id": "0550300001370000",
     "name": "Test Drive 6 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Test%20Drive%206%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Test%20Drive%206.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001360000 and rom copier for roms/sdc/Test Drive 6.chd"
   },
   "0550300001390000": {
     "id": "0550300001390000",
     "name": "Test Drive Le Mans [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Test%20Drive%20Le%20Mans%20(USA)%20(En,Fr,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Test%20Drive%20Le%20Mans.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001380000 and rom copier for roms/sdc/Test Drive Le Mans.chd"
   },
   "05503000013B0000": {
     "id": "05503000013B0000",
     "name": "Test Drive V-Rally [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Test%20Drive%20V-Rally%20(USA)%20(En,Fr,De).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Test%20Drive%20V-Rally.png",
     "region": "US",
     "description": "Forwarder installer for 05503000013a0000 and rom copier for roms/sdc/Test Drive V-Rally.chd"
   },
   "05503000013D0000": {
     "id": "05503000013D0000",
     "name": "Tetris 4D [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tetris%204D%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tetris%204D.png",
     "region": "US",
     "description": "Forwarder installer for 05503000013c0000 and rom copier for roms/sdc/Tetris 4D.chd"
   },
   "05503000013F0000": {
     "id": "05503000013F0000",
     "name": "The Grinch [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/AeroWings%20(Europe)%20(En,Fr,De).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/AeroWings.png",
     "region": "US",
     "description": "Forwarder installer for 05503000013e0000 and rom copier for roms/sdc/The Grinch.chd"
   },
   "0550300001410000": {
     "id": "0550300001410000",
     "name": "The House of the Dead 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/House%20of%20the%20Dead%202,%20The%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/The%20House%20of%20the%20Dead%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001400000 and rom copier for roms/sdc/The House of the Dead 2.chd"
   },
   "0550300001430000": {
     "id": "0550300001430000",
     "name": "The King of Fighters '99 - Evolution [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/King%20of%20Fighters,%20The%20-%20Evolution%20(USA)%20(En,Ja,Es,Pt).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/King%20of%20Fighters,%20The%20-%20Evolution.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001420000 and rom copier for roms/sdc/The King of Fighters '99 - Evolution.chd"
   },
   "0550300001450000": {
     "id": "0550300001450000",
     "name": "The King of Fighters 2000 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/King%20of%20Fighters%202000,%20The%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/The%20King%20of%20Fighters%202000.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001440000 and rom copier for roms/sdc/The King of Fighters 2000.chd"
   },
   "0550300001470000": {
     "id": "0550300001470000",
     "name": "The King of Fighters 2001 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/King%20of%20Fighters%202001,%20The%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/The%20King%20of%20Fighters%202001.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001460000 and rom copier for roms/sdc/The King of Fighters 2001.chd"
   },
   "0550300001490000": {
     "id": "0550300001490000",
     "name": "The King of Fighters 2002 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/King%20of%20Fighters%202002,%20The%20(Japan)%20(En,Ja).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/The%20King%20of%20Fighters%202002.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001480000 and rom copier for roms/sdc/The King of Fighters 2002.chd"
   },
   "05503000014B0000": {
     "id": "05503000014B0000",
     "name": "The Next Tetris - On-Line Edition [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Next%20Tetris,%20The%20-%20On-Line%20Edition%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/The%20Next%20Tetris%20-%20On-Line%20Edition.png",
     "region": "US",
     "description": "Forwarder installer for 05503000014a0000 and rom copier for roms/sdc/The Next Tetris - On-Line Edition.chd"
   },
   "05503000014D0000": {
     "id": "05503000014D0000",
     "name": "The Nomad Soul [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Nomad%20Soul,%20The%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/The%20Nomad%20Soul.png",
     "region": "US",
     "description": "Forwarder installer for 05503000014c0000 and rom copier for roms/sdc/The Nomad Soul.chd"
   },
   "05503000014F0000": {
     "id": "05503000014F0000",
     "name": "The Ring [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/GigaWing%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/GigaWing.png",
     "region": "US",
     "description": "Forwarder installer for 05503000014e0000 and rom copier for roms/sdc/The Ring.chd"
   },
   "0550300001510000": {
     "id": "0550300001510000",
     "name": "The Shinri Game [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Shinri%20Game,%20The%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/The%20Shinri%20Game.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001500000 and rom copier for roms/sdc/The Shinri Game.chd"
   },
   "0550300001530000": {
     "id": "0550300001530000",
     "name": "The Typing of the Dead [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Typing%20of%20the%20Date%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Typing%20of%20the%20Date.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001520000 and rom copier for roms/sdc/The Typing of the Dead.chd"
   },
   "0550300001550000": {
     "id": "0550300001550000",
     "name": "Time Stalkers [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Time%20Stalkers%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Time%20Stalkers.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001540000 and rom copier for roms/sdc/Time Stalkers.chd"
   },
   "0550300001570000": {
     "id": "0550300001570000",
     "name": "TNN Motorsports Hardcore Heat [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/TNN%20Motorsports%20Hardcore%20Heat%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/TNN%20Motorsports%20Hardcore%20Heat.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001560000 and rom copier for roms/sdc/TNN Motorsports Hardcore Heat.chd"
   },
   "0550300001590000": {
     "id": "0550300001590000",
     "name": "Tokusatsu Bouken Katsugeki Super Hero Retsuden [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tokusatsu%20Bouken%20Katsugeki%20Super%20Hero%20Retsuden%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tokusatsu%20Bouken%20Katsugeki%20Super%20Hero%20Retsuden.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001580000 and rom copier for roms/sdc/Tokusatsu Bouken Katsugeki Super Hero Retsuden.chd"
   },
   "05503000015B0000": {
     "id": "05503000015B0000",
     "name": "Tokyo Bus Guide - Bijin Bus Guide Tenjou Disc [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tokyo%20Bus%20Guide%20-%20Bijin%20Bus%20Guide%20Tenjou%20Disc%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tokyo%20Bus%20Guide%20-%20Bijin%20Bus%20Guide%20Tenjou%20Disc.png",
     "region": "US",
     "description": "Forwarder installer for 05503000015a0000 and rom copier for roms/sdc/Tokyo Bus Guide - Bijin Bus Guide Tenjou Disc.chd"
   },
   "05503000015D0000": {
     "id": "05503000015D0000",
     "name": "Tokyo Bus Guide Rev A [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tokyo%20Bus%20Guide%20(Japan)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tokyo%20Bus%20Guide.png",
     "region": "US",
     "description": "Forwarder installer for 05503000015c0000 and rom copier for roms/sdc/Tokyo Bus Guide Rev A.chd"
   },
   "05503000015F0000": {
     "id": "05503000015F0000",
     "name": "Tokyo Bus Guide [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tokyo%20Bus%20Guide%20(Japan)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tokyo%20Bus%20Guide.png",
     "region": "US",
     "description": "Forwarder installer for 05503000015e0000 and rom copier for roms/sdc/Tokyo Bus Guide.chd"
   },
   "0550300001610000": {
     "id": "0550300001610000",
     "name": "Tokyo Highway Challenge 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tokyo%20Highway%20Challenge%202%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tokyo%20Highway%20Challenge%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001600000 and rom copier for roms/sdc/Tokyo Highway Challenge 2.chd"
   },
   "0550300001630000": {
     "id": "0550300001630000",
     "name": "Tokyo Highway Challenge [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tokyo%20Highway%20Challenge%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tokyo%20Highway%20Challenge.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001620000 and rom copier for roms/sdc/Tokyo Highway Challenge.chd"
   },
   "0550300001650000": {
     "id": "0550300001650000",
     "name": "Tokyo Xtreme Racer 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tokyo%20Xtreme%20Racer%202%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tokyo%20Xtreme%20Racer%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001640000 and rom copier for roms/sdc/Tokyo Xtreme Racer 2.chd"
   },
   "0550300001670000": {
     "id": "0550300001670000",
     "name": "Tokyo Xtreme Racer [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tokyo%20Xtreme%20Racer%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tokyo%20Xtreme%20Racer.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001660000 and rom copier for roms/sdc/Tokyo Xtreme Racer.chd"
   },
   "0550300001690000": {
     "id": "0550300001690000",
     "name": "Tom Clancy's Rainbow Six - Rogue Spear + Mission Pack - Urban Operations [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tom%20Clancy's%20Rainbow%20Six%20-%20Rogue%20Spear%20+%20Mission%20Pack%20-%20Urban%20Operations%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tom%20Clancy's%20Rainbow%20Six%20-%20Rogue%20Spear%20+%20Mission%20Pack%20-%20Urban%20Operations.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001680000 and rom copier for roms/sdc/Tom Clancy's Rainbow Six - Rogue Spear + Mission Pack - Urban Operations.chd"
   },
   "05503000016B0000": {
     "id": "05503000016B0000",
     "name": "Tom Clancy's Rainbow Six with Eagle Watch Missions [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tom%20Clancy's%20Rainbow%20Six%20with%20Eagle%20Watch%20Missions%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tom%20Clancy's%20Rainbow%20Six%20with%20Eagle%20Watch%20Missions.png",
     "region": "US",
     "description": "Forwarder installer for 05503000016a0000 and rom copier for roms/sdc/Tom Clancy's Rainbow Six with Eagle Watch Missions.chd"
   },
   "05503000016D0000": {
     "id": "05503000016D0000",
     "name": "Tomb Raider - The Last Revelation [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tomb%20Raider%20-%20The%20Last%20Revelation%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tomb%20Raider%20-%20The%20Last%20Revelation.png",
     "region": "US",
     "description": "Forwarder installer for 05503000016c0000 and rom copier for roms/sdc/Tomb Raider - The Last Revelation.chd"
   },
   "05503000016F0000": {
     "id": "05503000016F0000",
     "name": "Tomb Raider Chronicles [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tomb%20Raider%20Chronicles%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tomb%20Raider%20Chronicles.png",
     "region": "US",
     "description": "Forwarder installer for 05503000016e0000 and rom copier for roms/sdc/Tomb Raider Chronicles.chd"
   },
   "0550300001710000": {
     "id": "0550300001710000",
     "name": "Tony Hawk's Pro Skater 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tony%20Hawk's%20Pro%20Skater%202%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tony%20Hawk's%20Pro%20Skater%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001700000 and rom copier for roms/sdc/Tony Hawk's Pro Skater 2.chd"
   },
   "0550300001730000": {
     "id": "0550300001730000",
     "name": "Tony Hawk's Pro Skater [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tony%20Hawk's%20Pro%20Skater%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tony%20Hawk's%20Pro%20Skater.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001720000 and rom copier for roms/sdc/Tony Hawk's Pro Skater.chd"
   },
   "0550300001750000": {
     "id": "0550300001750000",
     "name": "Tony Hawk's Skateboarding [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tony%20Hawk's%20Skateboarding%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tony%20Hawk's%20Skateboarding.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001740000 and rom copier for roms/sdc/Tony Hawk's Skateboarding.chd"
   },
   "0550300001770000": {
     "id": "0550300001770000",
     "name": "Totsugeki! Teketeke!! Toy Ranger [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Totsugeki!%20Teketeke!!%20Toy%20Ranger%20(Japan)%20(En,Ja,Fr,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Totsugeki!%20Teketeke!!%20Toy%20Ranger.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001760000 and rom copier for roms/sdc/Totsugeki! Teketeke!! Toy Ranger.chd"
   },
   "0550300001790000": {
     "id": "0550300001790000",
     "name": "Toy Commander [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Toy%20Commander%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Toy%20Commander.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001780000 and rom copier for roms/sdc/Toy Commander.chd"
   },
   "05503000017B0000": {
     "id": "05503000017B0000",
     "name": "Toy Racer [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Toy%20Racer%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Toy%20Racer.png",
     "region": "US",
     "description": "Forwarder installer for 05503000017a0000 and rom copier for roms/sdc/Toy Racer.chd"
   },
   "05503000017D0000": {
     "id": "05503000017D0000",
     "name": "Treasure Strike [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Treasure%20Strike%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Treasure%20Strike.png",
     "region": "US",
     "description": "Forwarder installer for 05503000017c0000 and rom copier for roms/sdc/Treasure Strike.chd"
   },
   "05503000017F0000": {
     "id": "05503000017F0000",
     "name": "TrickStyle [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/TrickStyle%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/TrickStyle.png",
     "region": "US",
     "description": "Forwarder installer for 05503000017e0000 and rom copier for roms/sdc/TrickStyle.chd"
   },
   "0550300001810000": {
     "id": "0550300001810000",
     "name": "Tricolore Crise - Art Palette [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tricolore%20Crise%20-%20Art%20Palette%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tricolore%20Crise%20-%20Art%20Palette.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001800000 and rom copier for roms/sdc/Tricolore Crise - Art Palette.chd"
   },
   "0550300001830000": {
     "id": "0550300001830000",
     "name": "Tricolore Crise [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tricolore%20Crise%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tricolore%20Crise.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001820000 and rom copier for roms/sdc/Tricolore Crise.chd"
   },
   "0550300001850000": {
     "id": "0550300001850000",
     "name": "Triggerheart Exelica [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Triggerheart%20Exelica%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Triggerheart%20Exelica.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001840000 and rom copier for roms/sdc/Triggerheart Exelica.chd"
   },
   "0550300001870000": {
     "id": "0550300001870000",
     "name": "Trizeal [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Trizeal%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Trizeal.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001860000 and rom copier for roms/sdc/Trizeal.chd"
   },
   "0550300001890000": {
     "id": "0550300001890000",
     "name": "Tsuki wa Higashi ni Hi wa Nishi ni - Operation Sanctuary [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tsuki%20wa%20Higashi%20ni%20Hi%20wa%20Nishi%20ni%20-%20Operation%20Sanctuary%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tsuki%20wa%20Higashi%20ni%20Hi%20wa%20Nishi%20ni%20-%20Operation%20Sanctuary.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001880000 and rom copier for roms/sdc/Tsuki wa Higashi ni Hi wa Nishi ni - Operation Sanctuary.chd"
   },
   "05503000018B0000": {
     "id": "05503000018B0000",
     "name": "Tsuushin Taisen Logic Battle Daisessen [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tsuushin%20Taisen%20Logic%20Battle%20Daisessen%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Tsuushin%20Taisen%20Logic%20Battle%20Daisessen.png",
     "region": "US",
     "description": "Forwarder installer for 05503000018a0000 and rom copier for roms/sdc/Tsuushin Taisen Logic Battle Daisessen.chd"
   },
   "05503000018D0000": {
     "id": "05503000018D0000",
     "name": "Twinkle Star Sprites [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Twinkle%20Star%20Sprites%20(Japan)%20(En,Ja,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Twinkle%20Star%20Sprites.png",
     "region": "US",
     "description": "Forwarder installer for 05503000018c0000 and rom copier for roms/sdc/Twinkle Star Sprites.chd"
   },
   "05503000018F0000": {
     "id": "05503000018F0000",
     "name": "Typing of the Date [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Typing%20of%20the%20Date%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Typing%20of%20the%20Date.png",
     "region": "US",
     "description": "Forwarder installer for 05503000018e0000 and rom copier for roms/sdc/Typing of the Date.chd"
   },
   "0550300001910000": {
     "id": "0550300001910000",
     "name": "UEFA Dream Soccer [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/UEFA%20Dream%20Soccer%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/UEFA%20Dream%20Soccer.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001900000 and rom copier for roms/sdc/UEFA Dream Soccer.chd"
   },
   "0550300001930000": {
     "id": "0550300001930000",
     "name": "UEFA Striker Beta [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/UEFA%20Striker%20(Europe)%20(En,Fr,De,Es,It,Nl).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/UEFA%20Striker.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001920000 and rom copier for roms/sdc/UEFA Striker Beta.chd"
   },
   "0550300001950000": {
     "id": "0550300001950000",
     "name": "UEFA Striker [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/UEFA%20Striker%20(Europe)%20(En,Fr,De,Es,It,Nl).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/UEFA%20Striker.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001940000 and rom copier for roms/sdc/UEFA Striker.chd"
   },
   "0550300001970000": {
     "id": "0550300001970000",
     "name": "Ultimate Fighting Championship Demo [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ultimate%20Fighting%20Championship%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ultimate%20Fighting%20Championship.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001960000 and rom copier for roms/sdc/Ultimate Fighting Championship Demo.chd"
   },
   "0550300001990000": {
     "id": "0550300001990000",
     "name": "Ultimate Fighting Championship [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ultimate%20Fighting%20Championship%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Ultimate%20Fighting%20Championship.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001980000 and rom copier for roms/sdc/Ultimate Fighting Championship.chd"
   },
   "05503000019B0000": {
     "id": "05503000019B0000",
     "name": "Under Defeat [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Under%20Defeat%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Under%20Defeat.png",
     "region": "US",
     "description": "Forwarder installer for 05503000019a0000 and rom copier for roms/sdc/Under Defeat.chd"
   },
   "05503000019D0000": {
     "id": "05503000019D0000",
     "name": "UnderCover AD2025 Kei [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/UnderCover%20AD2025%20Kei%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/UnderCover%20AD2025%20Kei.png",
     "region": "US",
     "description": "Forwarder installer for 05503000019c0000 and rom copier for roms/sdc/UnderCover AD2025 Kei.chd"
   },
   "05503000019F0000": {
     "id": "05503000019F0000",
     "name": "Unreal Tournament [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Unreal%20Tournament%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Unreal%20Tournament.png",
     "region": "US",
     "description": "Forwarder installer for 05503000019e0000 and rom copier for roms/sdc/Unreal Tournament.chd"
   },
   "0550300001A10000": {
     "id": "0550300001A10000",
     "name": "Urban Chaos [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Urban%20Chaos%20(Europe)%20(En,Fr).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Urban%20Chaos.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001a00000 and rom copier for roms/sdc/Urban Chaos.chd"
   },
   "0550300001A30000": {
     "id": "0550300001A30000",
     "name": "US Shenmue Disc #1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/US%20Shenmue%20(Japan)%20(En,Ja)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/US%20Shenmue%20Disc%20%231.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001a20000 and rom copier for roms/sdc/US Shenmue Disc #1.chd"
   },
   "0550300001A50000": {
     "id": "0550300001A50000",
     "name": "US Shenmue Disc #2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/US%20Shenmue%20(Japan)%20(En,Ja)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/US%20Shenmue%20Disc%20%232.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001a40000 and rom copier for roms/sdc/US Shenmue Disc #2.chd"
   },
   "0550300001A70000": {
     "id": "0550300001A70000",
     "name": "US Shenmue Disc #3 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/US%20Shenmue%20(Japan)%20(En,Ja)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/US%20Shenmue%20Disc%20%233.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001a60000 and rom copier for roms/sdc/US Shenmue Disc #3.chd"
   },
   "0550300001A90000": {
     "id": "0550300001A90000",
     "name": "US Shenmue Shenmue Passport [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Dream%20Passport.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001a80000 and rom copier for roms/sdc/US Shenmue Shenmue Passport.chd"
   },
   "0550300001AB0000": {
     "id": "0550300001AB0000",
     "name": "Utau - Tumbling Dice [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Utau%20-%20Tumbling%20Dice%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Utau%20-%20Tumbling%20Dice.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001aa0000 and rom copier for roms/sdc/Utau - Tumbling Dice.chd"
   },
   "0550300001AD0000": {
     "id": "0550300001AD0000",
     "name": "V-Rally 2 - Expert Edition [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/V-Rally%202%20-%20Expert%20Edition%20(Europe)%20(En,Fr,De).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/V-Rally%202%20-%20Expert%20Edition.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001ac0000 and rom copier for roms/sdc/V-Rally 2 - Expert Edition.chd"
   },
   "0550300001AF0000": {
     "id": "0550300001AF0000",
     "name": "Vampire Chronicle for Matching Service [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Vampire%20Chronicle%20for%20Matching%20Service%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Vampire%20Chronicle%20for%20Matching%20Service.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001ae0000 and rom copier for roms/sdc/Vampire Chronicle for Matching Service.chd"
   },
   "0550300001B10000": {
     "id": "0550300001B10000",
     "name": "Vanishing Point [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Vanishing%20Point%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Vanishing%20Point.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001b00000 and rom copier for roms/sdc/Vanishing Point.chd"
   },
   "0550300001B30000": {
     "id": "0550300001B30000",
     "name": "Vermilion Desert [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Vermilion%20Desert%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Vermilion%20Desert.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001b20000 and rom copier for roms/sdc/Vermilion Desert.chd"
   },
   "0550300001B50000": {
     "id": "0550300001B50000",
     "name": "Vigilante 8 - 2nd Offense [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Vigilante%208%20-%202nd%20Offense%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Vigilante%208%20-%202nd%20Offense.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001b40000 and rom copier for roms/sdc/Vigilante 8 - 2nd Offense.chd"
   },
   "0550300001B70000": {
     "id": "0550300001B70000",
     "name": "Virtua Athlete 2000 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Virtua%20Athlete%202000%20(USA)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Virtua%20Athlete%202000.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001b60000 and rom copier for roms/sdc/Virtua Athlete 2000.chd"
   },
   "0550300001B90000": {
     "id": "0550300001B90000",
     "name": "Virtua Cop 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Virtua%20Cop%202%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Virtua%20Cop%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001b80000 and rom copier for roms/sdc/Virtua Cop 2.chd"
   },
   "0550300001BB0000": {
     "id": "0550300001BB0000",
     "name": "Virtua Fighter 3tb [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Virtua%20Fighter%203tb%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Virtua%20Fighter%203tb.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001ba0000 and rom copier for roms/sdc/Virtua Fighter 3tb.chd"
   },
   "0550300001BD0000": {
     "id": "0550300001BD0000",
     "name": "Virtua Fighter History & VF4 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Virtua%20Fighter%203tb%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Virtua%20Fighter%203tb.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001bc0000 and rom copier for roms/sdc/Virtua Fighter History & VF4.chd"
   },
   "0550300001BF0000": {
     "id": "0550300001BF0000",
     "name": "Virtua Striker 2 Ver. 2000.1 Beta [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Virtua%20Striker%202%20Ver.%202000.1%20(Europe)%20(En,Ja,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Virtua%20Striker%202%20Ver.%202000.1%20Beta.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001be0000 and rom copier for roms/sdc/Virtua Striker 2 Ver. 2000.1 Beta.chd"
   },
   "0550300001C10000": {
     "id": "0550300001C10000",
     "name": "Virtua Striker 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Virtua%20Striker%202%20(USA)%20(En,Ja,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Virtua%20Striker%202.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001c00000 and rom copier for roms/sdc/Virtua Striker 2.chd"
   },
   "0550300001C30000": {
     "id": "0550300001C30000",
     "name": "Virtua Tennis - Sega Professional Tennis Beta [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Virtua%20Tennis%20-%20Sega%20Professional%20Tennis%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Virtua%20Tennis%20-%20Sega%20Professional%20Tennis.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001c20000 and rom copier for roms/sdc/Virtua Tennis - Sega Professional Tennis Beta.chd"
   },
   "0550300001C50000": {
     "id": "0550300001C50000",
     "name": "Virtua Tennis - Sega Professional Tennis [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Virtua%20Tennis%20-%20Sega%20Professional%20Tennis%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Virtua%20Tennis%20-%20Sega%20Professional%20Tennis.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001c40000 and rom copier for roms/sdc/Virtua Tennis - Sega Professional Tennis.chd"
   },
   "0550300001C70000": {
     "id": "0550300001C70000",
     "name": "Virtua Tennis 2 - Sega Professional Tennis [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Virtua%20Tennis%202%20-%20Sega%20Professional%20Tennis%20(Europe)%20(En,Fr,De,Es).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Virtua%20Tennis%202%20-%20Sega%20Professional%20Tennis.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001c60000 and rom copier for roms/sdc/Virtua Tennis 2 - Sega Professional Tennis.chd"
   },
   "0550300001C90000": {
     "id": "0550300001C90000",
     "name": "Virtua Tennis [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Virtua%20Tennis%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Virtua%20Tennis.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001c80000 and rom copier for roms/sdc/Virtua Tennis.chd"
   },
   "0550300001CB0000": {
     "id": "0550300001CB0000",
     "name": "Visual Park [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Visual%20Park%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Visual%20Park.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001ca0000 and rom copier for roms/sdc/Visual Park.chd"
   },
   "0550300001CD0000": {
     "id": "0550300001CD0000",
     "name": "Wacky Races [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Wacky%20Races%20(Europe)%20(En,Fr,De,Es,It,Nl).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Wacky%20Races.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001cc0000 and rom copier for roms/sdc/Wacky Races.chd"
   },
   "0550300001CF0000": {
     "id": "0550300001CF0000",
     "name": "Walt Disney World Quest - Magical Racing Tour [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Walt%20Disney%20World%20Quest%20-%20Magical%20Racing%20Tour%20(Europe)%20(En,Fr,De,Es,It).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Walt%20Disney%20World%20-%20Magical%20Racing%20Tour.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001ce0000 and rom copier for roms/sdc/Walt Disney World Quest - Magical Racing Tour.chd"
   },
   "0550300001D10000": {
     "id": "0550300001D10000",
     "name": "Weakness Hero Torauman DC Game Disc [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Weakness%20Hero%20Torauman%20DC%20(Japan)%20(Game%20Disc).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Weakness%20Hero%20Torauman%20DC%20Game%20Disc.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001d00000 and rom copier for roms/sdc/Weakness Hero Torauman DC Game Disc.chd"
   },
   "0550300001D30000": {
     "id": "0550300001D30000",
     "name": "Weakness Hero Torauman DC Omake Disc [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Weakness%20Hero%20Torauman%20DC%20(Japan)%20(Game%20Disc).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Weakness%20Hero%20Torauman%20DC%20Game%20Disc.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001d20000 and rom copier for roms/sdc/Weakness Hero Torauman DC Omake Disc.chd"
   },
   "0550300001D50000": {
     "id": "0550300001D50000",
     "name": "Web Browser 2.0 with SegaNet [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Web%20Browser%20(USA)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Web%20Browser.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001d40000 and rom copier for roms/sdc/Web Browser 2.0 with SegaNet.chd"
   },
   "0550300001D70000": {
     "id": "0550300001D70000",
     "name": "Web Browser 2.0 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Web%20Browser%20(USA)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Web%20Browser.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001d60000 and rom copier for roms/sdc/Web Browser 2.0.chd"
   },
   "0550300001D90000": {
     "id": "0550300001D90000",
     "name": "Web Browser 2.62 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Web%20Browser%20(USA)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Web%20Browser.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001d80000 and rom copier for roms/sdc/Web Browser 2.62.chd"
   },
   "0550300001DB0000": {
     "id": "0550300001DB0000",
     "name": "Web Browser [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Web%20Browser%20(USA)%20(Rev%20A).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Web%20Browser.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001da0000 and rom copier for roms/sdc/Web Browser.chd"
   },
   "0550300001DD0000": {
     "id": "0550300001DD0000",
     "name": "Web Mystery - Yochimu o Miru Neko Disc #1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Web%20Mystery%20-%20Yochimu%20o%20Miru%20Neko%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Web%20Mystery%20-%20Yochimu%20o%20Miru%20Neko%20Disc%20%231.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001dc0000 and rom copier for roms/sdc/Web Mystery - Yochimu o Miru Neko Disc #1.chd"
   },
   "0550300001DF0000": {
     "id": "0550300001DF0000",
     "name": "Web Mystery - Yochimu o Miru Neko Disc #2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Web%20Mystery%20-%20Yochimu%20o%20Miru%20Neko%20(Japan)%20(Disc%201).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Web%20Mystery%20-%20Yochimu%20o%20Miru%20Neko%20Disc%20%232.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001de0000 and rom copier for roms/sdc/Web Mystery - Yochimu o Miru Neko Disc #2.chd"
   },
   "0550300001E10000": {
     "id": "0550300001E10000",
     "name": "Wetrix+ [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Wetrix+%20(Europe)%20(En,Fr,De).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Wetrix+.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001e00000 and rom copier for roms/sdc/Wetrix+.chd"
   },
   "0550300001E30000": {
     "id": "0550300001E30000",
     "name": "What's Shenmue - Yukawa (Moto) Senmu o Sagase [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Doguu%20Senki%20-%20Haou%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Doguu%20Senki%20-%20Haou.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001e20000 and rom copier for roms/sdc/What's Shenmue - Yukawa (Moto) Senmu o Sagase.chd"
   },
   "0550300001E50000": {
     "id": "0550300001E50000",
     "name": "Who Wants to Be a Millionaire [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Who%20Wants%20to%20Be%20a%20Millionaire%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Who%20Wants%20To%20Be%20A%20Millionaire.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001e40000 and rom copier for roms/sdc/Who Wants to Be a Millionaire.chd"
   },
   "0550300001E70000": {
     "id": "0550300001E70000",
     "name": "Who Wants to Beat Up a Millionaire [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Who%20Wants%20to%20Beat%20Up%20a%20Millionaire%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Who%20Wants%20to%20Beat%20Up%20a%20Millionaire.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001e60000 and rom copier for roms/sdc/Who Wants to Beat Up a Millionaire.chd"
   },
   "0550300001E90000": {
     "id": "0550300001E90000",
     "name": "Wild Metal [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Wild%20Metal%20(Europe)%20(En,Fr,De,Es,It,Pt).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Wild%20Metal.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001e80000 and rom copier for roms/sdc/Wild Metal.chd"
   },
   "0550300001EB0000": {
     "id": "0550300001EB0000",
     "name": "Wind - A Breath of Heart [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Wind%20-%20A%20Breath%20of%20Heart%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Wind%20-%20A%20Breath%20of%20Heart.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001ea0000 and rom copier for roms/sdc/Wind - A Breath of Heart.chd"
   },
   "0550300001ED0000": {
     "id": "0550300001ED0000",
     "name": "Winning Post 4 - Program 2000 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Winning%20Post%204%20-%20Program%202000%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Winning%20Post%204%20-%20Program%202000.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001ec0000 and rom copier for roms/sdc/Winning Post 4 - Program 2000.chd"
   },
   "0550300001EF0000": {
     "id": "0550300001EF0000",
     "name": "World Neverland 2 Plus - Pluto Kyouwakoku Monogatari [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/World%20Neverland%202%20Plus%20-%20Pluto%20Kyouwakoku%20Monogatari%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/World%20Neverland%202%20Plus%20-%20Pluto%20Kyouwakoku%20Monogatari.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001ee0000 and rom copier for roms/sdc/World Neverland 2 Plus - Pluto Kyouwakoku Monogatari.chd"
   },
   "0550300001F10000": {
     "id": "0550300001F10000",
     "name": "World Neverland Plus - Olerud Oukoku Monogatari [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/World%20Neverland%20Plus%20-%20Olerud%20Oukoku%20Monogatari%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/World%20Neverland%20Plus%20-%20Olerud%20Oukoku%20Monogatari.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001f00000 and rom copier for roms/sdc/World Neverland Plus - Olerud Oukoku Monogatari.chd"
   },
   "0550300001F30000": {
     "id": "0550300001F30000",
     "name": "World Series Baseball 2K1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/World%20Series%20Baseball%202K1%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/World%20Series%20Baseball%202K1.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001f20000 and rom copier for roms/sdc/World Series Baseball 2K1.chd"
   },
   "0550300001F50000": {
     "id": "0550300001F50000",
     "name": "World Series Baseball 2K2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/World%20Series%20Baseball%202K2%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/World%20Series%20Baseball%202K2.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001f40000 and rom copier for roms/sdc/World Series Baseball 2K2.chd"
   },
   "0550300001F70000": {
     "id": "0550300001F70000",
     "name": "Worms Armageddon [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Worms%20Armageddon%20(Europe)%20(En,Fr,De,Nl,Sv,No,Da).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Worms%20Armageddon.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001f60000 and rom copier for roms/sdc/Worms Armageddon.chd"
   },
   "0550300001F90000": {
     "id": "0550300001F90000",
     "name": "Worms World Party [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Worms%20World%20Party%20(Europe)%20(En,Fr,De,Es,It,Nl,Sv,Da).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Worms%20World%20Party.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001f80000 and rom copier for roms/sdc/Worms World Party.chd"
   },
   "0550300001FB0000": {
     "id": "0550300001FB0000",
     "name": "WWF Attitude [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/WWF%20Attitude%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/WWF%20Attitude.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001fa0000 and rom copier for roms/sdc/WWF Attitude.chd"
   },
   "0550300001FD0000": {
     "id": "0550300001FD0000",
     "name": "WWF Royal Rumble [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/WWF%20Royal%20Rumble%20(Europe).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/WWF%20Royal%20Rumble.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001fc0000 and rom copier for roms/sdc/WWF Royal Rumble.chd"
   },
   "0550300001FF0000": {
     "id": "0550300001FF0000",
     "name": "Xtreme Sports [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Xtreme%20Sports%20(USA).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Xtreme%20Sports.png",
     "region": "US",
     "description": "Forwarder installer for 0550300001fe0000 and rom copier for roms/sdc/Xtreme Sports.chd"
   },
   "0550300002010000": {
     "id": "0550300002010000",
     "name": "Yoshia no Oka de Nekoronde [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Yoshia%20no%20Oka%20de%20Nekoronde...%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Yoshia%20no%20Oka%20de%20Nekoronde.png",
     "region": "US",
     "description": "Forwarder installer for 0550300002000000 and rom copier for roms/sdc/Yoshia no Oka de Nekoronde.chd"
   },
   "0550300002030000": {
     "id": "0550300002030000",
     "name": "Yu Suzuki Game Works Vol. 1 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Yu%20Suzuki%20Game%20Works%20Vol.%201%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Yu%20Suzuki%20Game%20Works%20Vol.%201.png",
     "region": "US",
     "description": "Forwarder installer for 0550300002020000 and rom copier for roms/sdc/Yu Suzuki Game Works Vol. 1.chd"
   },
   "0550300002050000": {
     "id": "0550300002050000",
     "name": "Yukawa Moto Senmu no Otakara Sagashi [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Yukawa%20Moto%20Senmu%20no%20Otakara%20Sagashi%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Yukawa%20Moto%20Senmu%20no%20Otakara%20Sagashi.png",
     "region": "US",
     "description": "Forwarder installer for 0550300002040000 and rom copier for roms/sdc/Yukawa Moto Senmu no Otakara Sagashi.chd"
   },
   "0550300002070000": {
     "id": "0550300002070000",
     "name": "Yukigatari [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Yukigatari%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Yukigatari.png",
     "region": "US",
     "description": "Forwarder installer for 0550300002060000 and rom copier for roms/sdc/Yukigatari.chd"
   },
   "0550300002090000": {
     "id": "0550300002090000",
     "name": "Yume Baken '99 - Internet [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Yume%20Baken%20'99%20-%20Internet%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Yume%20Baken%20'99%20-%20Internet.png",
     "region": "US",
     "description": "Forwarder installer for 0550300002080000 and rom copier for roms/sdc/Yume Baken '99 - Internet.chd"
   },
   "05503000020B0000": {
     "id": "05503000020B0000",
     "name": "Yume no Tsubasa - Fate of Heart [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Yume%20no%20Tsubasa%20-%20Fate%20of%20Heart%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Yume%20no%20Tsubasa%20-%20Fate%20of%20Heart.png",
     "region": "US",
     "description": "Forwarder installer for 05503000020a0000 and rom copier for roms/sdc/Yume no Tsubasa - Fate of Heart.chd"
   },
   "05503000020D0000": {
     "id": "05503000020D0000",
     "name": "Yuukyuu Gensoukyoku 3 - Perpetual Blue [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Yuukyuu%20Gensoukyoku%203%20-%20Perpetual%20Blue%20(Japan).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Yuukyuu%20Gensoukyoku%203%20-%20Perpetual%20Blue.png",
     "region": "US",
     "description": "Forwarder installer for 05503000020c0000 and rom copier for roms/sdc/Yuukyuu Gensoukyoku 3 - Perpetual Blue.chd"
   },
   "05503000020F0000": {
     "id": "05503000020F0000",
     "name": "Zero Gunner 2 [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Zero%20Gunner%202%20(Japan)%20(En,Ja).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Zero%20Gunner%202.png",
     "region": "US",
     "description": "Forwarder installer for 05503000020e0000 and rom copier for roms/sdc/Zero Gunner 2.chd"
   },
   "0550300002110000": {
     "id": "0550300002110000",
     "name": "Zombie Revenge [sdc]",
-    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Zombie%20Revenge%20(Europe)%20(En,Ja).png",
+    "iconUrl": "https://raw.githubusercontent.com/teknik-app/forwarder-images/main/sdc/Zombie%20Revenge.png",
     "region": "US",
     "description": "Forwarder installer for 0550300002100000 and rom copier for roms/sdc/Zombie Revenge.chd"
   }


### PR DESCRIPTION
All links to github images for SDC were broken, this update json fixed that. All have been checked.